### PR TITLE
Trigger rollout with a change to spec.template

### DIFF
--- a/deployment/human-connection/deployment-backend.yaml
+++ b/deployment/human-connection/deployment-backend.yaml
@@ -4,8 +4,6 @@
   metadata:
     name: nitro-backend
     namespace: human-connection
-    labels:
-      commit: "COMMIT"
   spec:
     replicas: 1
     minReadySeconds: 15
@@ -20,6 +18,7 @@
     template:
       metadata:
         labels:
+          human-connection.org/commit: COMMIT
           human-connection.org/selector: deployment-human-connection-backend
         name: "nitro-backend"
       spec:

--- a/deployment/human-connection/deployment-web.yaml
+++ b/deployment/human-connection/deployment-web.yaml
@@ -3,8 +3,6 @@ kind: Deployment
 metadata:
   name: nitro-web
   namespace: human-connection
-  labels:
-    commit: "COMMIT"
 spec:
   replicas: 2
   minReadySeconds: 15
@@ -15,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        human-connection.org/commit: COMMIT
         human-connection.org/selector: deployment-human-connection-web
       name: nitro-web
     spec:

--- a/scripts/patch-deployment.yaml
+++ b/scripts/patch-deployment.yaml
@@ -1,3 +1,5 @@
-metadata:
-  labels:
-    commit: <COMMIT>
+spec:
+  template:
+    metadata:
+      labels:
+        human-connection.org/commit: <COMMIT>


### PR DESCRIPTION
The documentation clearly says:
```
Note: A Deployment’s rollout is triggered if and only if the
Deployment’s pod template (that is, .spec.template) is changed, for
example if the labels or container images of the template are updated.
Other updates, such as scaling the Deployment, do not trigger a
rollout.
```

Read: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#updating-a-deployment