### PR TITLE
Use github emojis if possible

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,7 @@ about: Create a report to help us improve
 
 ---
 
-## 🐛 Bugreport
+## :bug: Bugreport
 <!-- Describe your issue in detail. Include screenshots if needed. Give us as much information as possible. Use a clear and concise description of what the bug is.-->
 
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,7 @@ about: Suggest an idea for this project
 
 ---
 
-## 🚀 Feature
+## :rocket: Feature
 <!-- Describe the Feature. -->
 
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -6,5 +6,5 @@ about: If you need help understanding HumanConnection.
 <!-- If you need an answer right away, visit the HumanConnection Discord:
 https://discord.gg/Q3mpcgr -->
 
-## 💬 Question
+## :speech_balloon: Question
 <!-- Describe your Question in detail. Include screenshots and drawings if needed. -->


### PR DESCRIPTION
cc @ulfgebhardt
Unicode emojis are not displayed in my browser for all font sizes.
Except in the title of an issue or PR you can use `:emoji:` notation
to let Github render emojis. That's possible in commit messages as well
as the description of PRs/issues and in comments.

## Pullrequest
<!-- Describe the Pullrequest. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- [X] None

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Env-Variables adjustment needed
- [ ] Breaking/critical change
-->
- [X] None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
<!-- Maintainers will check the Tests
- [ ] Test1
- [ ] Test2
-->
- [X] None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
