### PR TITLE
2019/kw15/Access_Settings_from_Profile_as_Owner

### DIFF
--- a/webapp/components/ContentMenu.vue
+++ b/webapp/components/ContentMenu.vue
@@ -111,9 +111,8 @@ export default {
 
       if (this.isOwner && this.resourceType === 'user') {
         routes.push({
-          name: this.$t(`settings.data.name`),
-          // eslint-disable-next-line vue/no-side-effects-in-computed-properties
-          callback: () => this.$router.push('/settings'),
+          name: this.$t(`settings.name`),
+          path: '/settings',
           icon: 'edit'
         })
       }


### PR DESCRIPTION
## Pullrequest
<!-- Describe the Pullrequest. -->
![image](https://user-images.githubusercontent.com/1238238/55796843-31b02880-5acb-11e9-8c8c-5b5bcdb6c812.png)
Access Settings from Profile as Owner -> link was already present, but text was misleading (corrected), removed eslint exception

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- [X] fixes https://github.com/Human-Connection/Human-Connection/issues/400

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Env-Variables adjustment needed
- [ ] Breaking/critical change
-->
- [X] None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
<!-- Maintainers will check the Tests
- [ ] Test1
- [ ] Test2
-->
- [X] None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
