### PR TITLE
Try to fix flaky "ReportContent.feature"

### DIFF
--- a/cypress/integration/common/report.js
+++ b/cypress/integration/common/report.js
@@ -55,7 +55,7 @@ When(
     cy.contains('.ds-card', davidIrvingName)
       .find('.content-menu-trigger')
       .first()
-      .click()
+      .click({force: true})
 
     cy.get('.popover .ds-menu-item-link')
       .contains('Report User')


### PR DESCRIPTION
## Pullrequest
At the moment, the most flaky cypress test is "ReportContent.feature" when it tries to click on the ContentMenu on the user profile.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- [X] None

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Env-Variables adjustment needed
- [ ] Breaking/critical change
-->
- [X] None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
<!-- Maintainers will check the Tests
- [ ] Test1
- [ ] Test2
-->
- [X] None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None

```

  Report and Moderate
    ✓ Report a post from various pages (example #1) (7462ms)
    ✓ Report a post from various pages (example #2) (6963ms)
    1) Report user
    ✓ Review reported content (6731ms)
    ✓ Normal user can't see the moderation page (3142ms)
  4 passing (35s)
  1 failing
  1) Report and Moderate Report user:
     CypressError: Timed out retrying: cy.click() failed because this element is not visible:
<button class="ds-button content-menu-trigger ds-button-size-small ds-button-ghost">...</button>
This element '<button.ds-button.content-menu-trigger.ds-button-size-small.ds-button-ghost>' is not visible because it has an effective width and height of: '0 x 0' pixels.
Fix this problem, or use {force: true} to disable error checking.
https://on.cypress.io/element-cannot-be-interacted-with
      at Object.cypressErr (http://localhost:3000/__cypress/runner/cypress_runner.js:65727:11)
      at Object.throwErr (http://localhost:3000/__cypress/runner/cypress_runner.js:65692:18)
      at Object.throwErrByPath (http://localhost:3000/__cypress/runner/cypress_runner.js:65719:17)
      at Object.retry (http://localhost:3000/__cypress/runner/cypress_runner.js:59237:16)
      at retryActionability (http://localhost:3000/__cypress/runner/cypress_runner.js:50983:19)
      at tryCatcher (http://localhost:3000/__cypress/runner/cypress_runner.js:131273:23)
      at Function.Promise.attempt.Promise.try (http://localhost:3000/__cypress/runner/cypress_runner.js:128647:29)
      at tryFn (http://localhost:3000/__cypress/runner/cypress_runner.js:59473:24)
      at whenStable (http://localhost:3000/__cypress/runner/cypress_runner.js:59501:12)
      at http://localhost:3000/__cypress/runner/cypress_runner.js:59261:16
      at tryCatcher (http://localhost:3000/__cypress/runner/cypress_runner.js:131273:23)
      at Promise._settlePromiseFromHandler (http://localhost:3000/__cypress/runner/cypress_runner.js:129291:31)
      at Promise._settlePromise (http://localhost:3000/__cypress/runner/cypress_runner.js:129348:18)
      at Promise._settlePromise0 (http://localhost:3000/__cypress/runner/cypress_runner.js:129393:10)
      at Promise._settlePromises (http://localhost:3000/__cypress/runner/cypress_runner.js:129472:18)
      at Promise._fulfill (http://localhost:3000/__cypress/runner/cypress_runner.js:129417:18)
```
