### PR TITLE
Prevent `argument list too long` error

### DIFF
--- a/deployment/legacy-migration/maintenance-worker/binaries/import_legacy_uploads
+++ b/deployment/legacy-migration/maintenance-worker/binaries/import_legacy_uploads
@@ -9,4 +9,4 @@ do
   fi
 done
 
-rsync --archive --update --verbose ${SSH_USERNAME}@${SSH_HOST}:${UPLOADS_DIRECTORY}/* /uploads/
+rsync --archive --update --verbose ${SSH_USERNAME}@${SSH_HOST}:${UPLOADS_DIRECTORY}/ /uploads/


### PR DESCRIPTION
## Pullrequest
When downloading the current 72836 uploads from production, we run into bash's `argument list too long` error.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- [X] None

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Env-Variables adjustment needed
- [ ] Breaking/critical change
-->
- [X] None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
<!-- Maintainers will check the Tests
- [ ] Test1
- [ ] Test2
-->
- [X] None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
