### PR TITLE
Refactor to use <img> instead of <hc-image> component for images

### DIFF
--- a/webapp/components/Empty.vue
+++ b/webapp/components/Empty.vue
@@ -5,8 +5,8 @@
     :margin="margin"
   >
     <ds-text>
-      <hc-image
-        :image-props="{ src: imgSrc }"
+      <img
+        :src="iconPath"
         width="80"
         class="hc-empty-icon"
         style="margin-bottom: 5px"
@@ -24,12 +24,8 @@
 </template>
 
 <script>
-import HcImage from '~/components/Image'
 export default {
   name: 'HcEmpty',
-  components: {
-    HcImage
-  },
   props: {
     /**
      * Icon that should be shown
@@ -58,7 +54,7 @@ export default {
     }
   },
   computed: {
-    imgSrc() {
+    iconPath() {
       return `/img/empty/${this.icon}.svg`
     }
   }


### PR DESCRIPTION
## Pullrequest
<!-- Describe the Pullrequest. -->
This PR has been requested due to request from @roschaefer due to the discussion on [this PR](https://github.com/Human-Connection/Human-Connection/pull/614)
Reverts Empty.vue to use `<img>` tag instead of Image component
### Issues
<!-- Which Issues does this fix, which are related?
- 
- 
-->
- [X] fixes #613 
- [X] relates #594 

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Env-Variables adjustment needed
- [ ] Breaking/critical change
-->
- [X] Tests passing

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
<!-- Maintainers will check the Tests
- [ ] Test1
- [ ] Test2
-->
- [X] Access any post with no comment from the home page. You should see the image below
<img width="822" alt="Screen Shot 2019-05-16 at 4 30 42 PM" src="https://user-images.githubusercontent.com/1543546/57858276-6796aa00-77f9-11e9-9e74-69f8b597ecfe.png">


### Todo
<!-- In case some parts are still missing, list them here. -->
- [ ] Add cypress tests to test when images do not appear for comment
