### PR TITLE
Fix duplicate tags by using the name as the id

### DIFF
--- a/deployment/legacy-migration/maintenance-worker/migration/neo4j/contributions.cql
+++ b/deployment/legacy-migration/maintenance-worker/migration/neo4j/contributions.cql
@@ -20,6 +20,6 @@ MATCH (c:Category {id: categoryId})
 MERGE (p)-[:CATEGORIZED]->(c)
 WITH p, post.tags AS tags
 UNWIND tags AS tag
-MERGE (t:Tag {id: apoc.create.uuid(), name: tag})
+MERGE (t:Tag {id: tag, name: tag})
 MERGE (p)-[:TAGGED]->(t)
 ;


### PR DESCRIPTION
@ulfgebhardt: I wondered about the list of tags after importing the
legacy db. It seems, each tag has at most 1 contribution. I guess it's
because we create a unique id for each tag, so two tags with the same
`name` e.g. `#hashtag` and `#hashtag` are not de-duplicated.

I'm currently sitting in the train and cannot run the data import myself, could
you double-check?

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


![Screenshot - 2019-05-23T155758 570](https://user-images.githubusercontent.com/2110676/58259194-5b1fcd80-7d74-11e9-9728-08a8c7c70c01.png)

