### PR TITLE
Fix placeholder text not translating bug

### DIFF
--- a/webapp/components/Editor/index.vue
+++ b/webapp/components/Editor/index.vue
@@ -327,10 +327,18 @@ export default {
       },
     },
   },
+  mounted() {
+    this.$root.$on('changeLanguage', () => {
+      this.changePlaceHolderText()
+    })
+  },
   beforeDestroy() {
     this.editor.destroy()
   },
   methods: {
+    changePlaceHolderText() {
+      this.editor.extensions.options.placeholder.emptyNodeText = this.$t('editor.placeholder')
+    },
     // navigate to the previous item
     // if it's the first item, navigate to the last one
     upHandler() {

--- a/webapp/components/LocaleSwitch.vue
+++ b/webapp/components/LocaleSwitch.vue
@@ -14,7 +14,8 @@
       <ds-icon
         style="margin-right: 2px;"
         name="globe"
-      /> {{ current.code.toUpperCase() }}
+      />
+      {{ current.code.toUpperCase() }}
       <ds-icon
         style="margin-left: 2px"
         size="xx-small"
@@ -78,6 +79,7 @@ export default {
     changeLanguage(locale, toggleMenu) {
       this.$i18n.set(locale)
       toggleMenu()
+      this.$root.$emit('changeLanguage')
     },
     matcher(locale) {
       return locale === this.$i18n.locale()


### PR DESCRIPTION
- tiptap-extensions are not reactive
- we must call a method to change them dynamically
- emit changeLanguage event, which is listened for by the Editor component, which then calls a method to set the emptyNodeText of tiptap

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?

- relates #XXX
-->
- fixes #583 
