### PR TITLE
Fix #470

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ install:
   - wait-on http://localhost:7474
 
 script:
+  - export CYPRESS_RETRIES=1
+  - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH"
   # Backend
   - docker-compose exec backend yarn run lint
   - docker-compose exec backend yarn run test:jest --ci --verbose=false --coverage
@@ -34,7 +37,9 @@ script:
   - docker-compose exec webapp yarn run test --ci --verbose=false --coverage
   - docker-compose exec -d backend yarn run test:before:seeder
   # Fullstack
-  - CYPRESS_RETRIES=1 yarn run cypress:run
+  # Disable recording cypress tests if we just update dependencies. This is to
+  # avoid running out of quota.
+  - if [[ $BRANCH == *"dependabot"* ]]; then yarn run cypress:run; else yarn run cypress:run --record; fi
   # Coverage
   - codecov
 


### PR DESCRIPTION
Define env variables $BRANCH and $CYPRESS_RETRIES

Source: https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/

------

Cypress is looking for a env var by default. See: https://docs.cypress.io/guides/guides/command-line.html#cypress-run

So I guess, all what we have to do is to give the env var another name.
I also added a measure to avoid running out of quota: Disable recording
if dependabot just updates dependencies.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fix #470

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
