### PR TITLE
Fix #799

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,4 +24,5 @@ RUN yarn run build
 FROM base as production
 ENV NODE_ENV=production
 COPY --from=builder /nitro-backend/dist ./dist
+COPY ./public/img/ ./public/img/
 RUN yarn install --frozen-lockfile --non-interactive


### PR DESCRIPTION
For target `production` the badges were simply not copied. It also
explains why we never saw that error in development. For development we
use docker build target `build-and-test`.

FYI: @ulfgebhardt @Tirokk @ogerly

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fix #799 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
