### PR TITLE
Turn off $root listeners in beforeDestroy

### DIFF
--- a/webapp/components/Editor/index.vue
+++ b/webapp/components/Editor/index.vue
@@ -323,6 +323,7 @@ export default {
     })
   },
   beforeDestroy() {
+    this.$root.$off('changeLanguage')
     this.editor.destroy()
   },
   methods: {

--- a/webapp/components/comments/CommentList/index.vue
+++ b/webapp/components/comments/CommentList/index.vue
@@ -54,6 +54,9 @@ export default {
       this.refetchPostComments()
     })
   },
+  beforeDestroy() {
+    this.$root.$off('refetchPostComments')
+  },
   methods: {
     refetchPostComments() {
       if (this.$apollo.queries.Post) {


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?

- relates #XXX
-->
- fixes #804 

long-term we want to avoid these types of events, but in the short-term, or where necessary, we should be turning these off in a `beforeDestroy` lifecycle method