### PR TITLE
Page size of 12 entries on / page

### DIFF
--- a/webapp/pages/index.vue
+++ b/webapp/pages/index.vue
@@ -45,7 +45,7 @@ export default {
       // Initialize your apollo data
       Post: [],
       page: 1,
-      pageSize: 10,
+      pageSize: 12,
       filter: {},
     }
   },


### PR DESCRIPTION
It annoys me that there are gaps for the 3 column layout, even if there
are more records left. So, the newsfeed layout has 1 column on mobile, 2
columns on tablet, and 3 columns on a desktop pc. So we should choose a
page size which is dividable by 1,2 and 3 that is 6. I have chosen 12
which is 2*6 to avoid clicking the reload posts button so often.

![Screenshot - 2019-06-22T090929 363](https://user-images.githubusercontent.com/2110676/59960768-60844b00-94cd-11e9-92ed-0e060eb80fb8.png)


## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
