### PR TITLE
Refactor CreateComments functionality

### DIFF
--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -3375,12 +3375,7 @@ extsprintf@^1.2.0:
 
 faker@Marak/faker.js#master:
   version "4.1.0"
-  uid "10bfb9f467b0ac2b8912ffc15690b50ef3244f09"
   resolved "https://codeload.github.com/Marak/faker.js/tar.gz/10bfb9f467b0ac2b8912ffc15690b50ef3244f09"
-
-"faker@git+https://github.com/Marak/faker.js.git#master":
-  version "4.1.0"
-  resolved "git+https://github.com/Marak/faker.js.git#10bfb9f467b0ac2b8912ffc15690b50ef3244f09"
 
 fast-deep-equal@^2.0.1:
   version "2.0.1"

--- a/webapp/components/comments/CommentForm/spec.js
+++ b/webapp/components/comments/CommentForm/spec.js
@@ -81,11 +81,6 @@ describe('CommentForm.vue', () => {
         expect(cancelMethodSpy).toHaveBeenCalledTimes(1)
       })
 
-      it('emits a method call with the returned comment', () => {
-        const rootWrapper = createWrapper(wrapper.vm.$root)
-        expect(rootWrapper.emitted().refetchPostComments.length).toEqual(1)
-      })
-
       describe('mutation fails', () => {
         it('shows the error toaster', async () => {
           await wrapper.find('form').trigger('submit')

--- a/webapp/components/comments/CommentForm/spec.js
+++ b/webapp/components/comments/CommentForm/spec.js
@@ -1,4 +1,4 @@
-import { mount, createLocalVue, createWrapper } from '@vue/test-utils'
+import { mount, createLocalVue } from '@vue/test-utils'
 import CommentForm from './index.vue'
 import Styleguide from '@human-connection/styleguide'
 import Vuex from 'vuex'

--- a/webapp/components/comments/CommentList/CommentList.spec.js
+++ b/webapp/components/comments/CommentList/CommentList.spec.js
@@ -88,10 +88,5 @@ describe('CommentList.vue', () => {
     it('displays comments when there are comments to display', () => {
       expect(wrapper.find('div.comments').text()).toEqual('this is a comment')
     })
-
-    it("refetches a post's comments from the backend", () => {
-      wrapper.vm.refetchPostComments()
-      expect(mocks.$apollo.queries.Post.refetch).toHaveBeenCalledTimes(1)
-    })
   })
 })

--- a/webapp/components/comments/CommentList/index.vue
+++ b/webapp/components/comments/CommentList/index.vue
@@ -30,6 +30,7 @@
 <script>
 import Comment from '~/components/Comment.vue'
 import HcEmpty from '~/components/Empty.vue'
+import PostCommentsQuery from '~/graphql/PostCommentsQuery.js'
 
 export default {
   components: {
@@ -49,25 +50,10 @@ export default {
       this.comments = post[0].comments || []
     },
   },
-  mounted() {
-    this.$root.$on('refetchPostComments', () => {
-      this.refetchPostComments()
-    })
-  },
-  beforeDestroy() {
-    this.$root.$off('refetchPostComments')
-  },
-  methods: {
-    refetchPostComments() {
-      if (this.$apollo.queries.Post) {
-        this.$apollo.queries.Post.refetch()
-      }
-    },
-  },
   apollo: {
     Post: {
       query() {
-        return require('~/graphql/PostCommentsQuery.js').default(this)
+        return PostCommentsQuery(this.$i18n)
       },
       variables() {
         return {

--- a/webapp/graphql/CommentMutations.js
+++ b/webapp/graphql/CommentMutations.js
@@ -1,0 +1,23 @@
+import gql from 'graphql-tag'
+
+export default () => {
+  return {
+    CreateComment: gql`
+      mutation($postId: ID, $content: String!) {
+        CreateComment(postId: $postId, content: $content) {
+          id
+          contentExcerpt
+          author {
+            id
+            slug
+            name
+            avatar
+          }
+          createdAt
+          deleted
+          disabled
+        }
+      }
+    `,
+  }
+}

--- a/webapp/graphql/PostCommentsQuery.js
+++ b/webapp/graphql/PostCommentsQuery.js
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag'
 
-export default app => {
-  const lang = app.$i18n.locale().toUpperCase()
+export default i18n => {
+  const lang = i18n.locale().toUpperCase()
   return gql(`
     query Post($slug: String!) {
       Post(slug: $slug) {


### PR DESCRIPTION
- update apollo cache on successful mutation
- remove global event listener
- avoid refetch Post to update CommentsList
- return comment with its author from resolver

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?

- relates #XXX
-->
- fixes #900 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [ ] Should I refactor the backend tests now that we return the comment with its author? 
