### PR TITLE
region and place is no longer created twice.

### DIFF
--- a/backend/src/middleware/nodes/locations.js
+++ b/backend/src/middleware/nodes/locations.js
@@ -87,6 +87,9 @@ const createOrUpdateLocations = async (userId, locationName, driver) => {
   }
 
   const session = driver.session()
+  if (data.place_type.length > 1) {
+    data.id = 'region.' + data.id.split('.')[1]
+  }
   await createLocation(session, data)
 
   let parent = data


### PR DESCRIPTION
## 🍰 Pullrequest
the problem is illustrated by the following example 
("Hamburg, Germany) and 
(Hamburg, Hamburg, Germany) 
to recognize.
In this case, Hamburg is created twice. 
There is a problem with the place.$ID and place.$place_type 
For capitals and large cities they have two place.$place_type (region,place) 
but the $ID is not region.$ID but place.ID. 
i changed this conflict. 
if a place.$place_type contains two specifications. 
the place.$ID is changed from "place" to "region". 
otherwise there can be conflicts in the DB like in the case of hamburg.


### Issues
- fixes https://github.com/Human-Connection/Human-Connection/issues/850
 

### Todo
- [ ] this should really be checked again. Hamburg is the only place i noticed so far. but i think there will be more cases. 
