### PR TITLE
Bugfix: Signup email was missing email query param

### DIFF
--- a/backend/src/middleware/email/templates/signup.js
+++ b/backend/src/middleware/email/templates/signup.js
@@ -11,6 +11,7 @@ export const signupTemplate = options => {
   } = options
   const actionUrl = new URL('/registration/create-user-account', CONFIG.CLIENT_URI)
   actionUrl.searchParams.set('nonce', nonce)
+  actionUrl.searchParams.set('email', email)
 
   return {
     to: email,


### PR DESCRIPTION
## 🍰 Pullrequest
Together with @victorrms2 I tried out the "Signup users as admin" feature and we ran into this.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
