### PR TITLE
Sledgehammer the file permission problem on docker

### DIFF
--- a/docker-compose.travis.yml
+++ b/docker-compose.travis.yml
@@ -26,9 +26,4 @@ services:
     ports:
       - 4001:4001
       - 4123:4123
-  neo4j:
-    environment:
-      - NEO4J_AUTH=none
-    ports:
-      - 7687:7687
-      - 7474:7474
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     networks:
       - hc-network
     environment:
+      - NUXT_BUILD=.nuxt-dist
       - HOST=0.0.0.0
       - GRAPHQL_URI=http://backend:4000
       - MAPBOX_TOKEN="pk.eyJ1IjoiaHVtYW4tY29ubmVjdGlvbiIsImEiOiJjajl0cnBubGoweTVlM3VwZ2lzNTNud3ZtIn0.bZ8KK9l70omjXbEkkbHGsQ"

--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -61,6 +61,8 @@ typings/
 
 # nuxt.js build output
 .nuxt
+# also the build output in docker container
+.nuxt-dist
 
 # Nuxt generate
 dist

--- a/webapp/nuxt.config.js
+++ b/webapp/nuxt.config.js
@@ -10,7 +10,10 @@ const styleguideStyles = process.env.STYLEGUIDE_DEV
     ]
   : '@human-connection/styleguide/dist/shared.scss'
 
+const buildDir = process.env.NUXT_BUILD || '.nuxt'
+
 module.exports = {
+  buildDir,
   mode: 'universal',
 
   dev: dev,


### PR DESCRIPTION
NuxtJS wants to write into .nuxt. If the docker container writes into
.nuxt it will have the file permissions of the docker container user
even on the host system. So on the host system you cannot remove the
folder .nuxt anymore. This gets in the way of running NuxtJS on the host
system.

Now, host system and container will use different folder locations: `.nuxt` and `.nuxt-dist` respectively.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
