### PR TITLE
Add static page for data privacy

### DIFF
--- a/webapp/pages/data-privacy.vue
+++ b/webapp/pages/data-privacy.vue
@@ -5,8 +5,379 @@
     </ds-space>
     <ds-container>
       <ds-space margin-top="large">
-        <ds-text>{{ $t('site.data-privacy') }}</ds-text>
-        <ds-text>...</ds-text>
+        <p>
+          für
+          <a href="https://alpha.human-connection.org" target="_blank">
+            https://alpha.human-connection.org
+          </a>
+        </p>
+        <p>
+          Stand vom
+          <strong>17. Juni 2019</strong>
+        </p>
+        <br />
+        <p>
+          Human Connection gGmbH bietet über die Internetseite
+          <a href="https://alpha.human-connection.org" target="_blank">
+            https://alpha.human-connection.org
+          </a>
+          den Nutzern und Interessierten umfangreiche Informationen. Dabei liegt uns der
+          vertrauensvolle und sichere Umgang mit Deinen personenbezogenen Daten sehr am Herzen.
+        </p>
+        <br />
+        <p>
+          Auf Grund von rechtlichen und technischen Veränderungen, passen wir die
+          Datenschutzerklärung bei Bedarf an. Es ist jeweils die aktuellste Fassung unserer hier
+          veröffentlichten Datenschutzerklärung gültig.
+        </p>
+        <h1>Verantwortlicher</h1>
+        <p>
+          Verantwortlicher im Sinne der Datenschutz-Grundverordnung, sonstiger in den
+          Mitgliedstaaten der Europäischen Union geltenden Datenschutzgesetze und anderer
+          Bestimmungen mit datenschutzrechtlichem Charakter ist die:
+        </p>
+        <br />
+        <p><strong>Human Connection gGmbH</strong></p>
+        <p>Bahnhofstr. 11</p>
+        <p>73235 Weilheim / Teck</p>
+        <p>
+          <strong>Geschäftsführer:</strong>
+          Dennis Hack
+        </p>
+        <p>
+          <strong>Telefon:</strong>
+          +49 151 43 80 42 22
+        </p>
+        <p>
+          <strong>E-Mail:</strong>
+          <a href="mailto:info@human-connection.org">info@human-connection.org</a>
+        </p>
+        <p>
+          <strong>Web:</strong>
+          <a href="https://human-connection.org" target="_blank">https://human-connection.org</a>
+        </p>
+        <br />
+        <h1>Datenschutzbeauftragter</h1>
+        <p><strong>Unser Datenschutzbeauftragte ist so erreichbar</strong></p>
+        <br />
+        <p>
+          <strong>E-Mail:</strong>
+          <a href="mailto:datenschutz@human-connection.org">datenschutz@human-connection.org</a>
+        </p>
+        <br />
+        <h1>Zwecke der Datenverarbeitung</h1>
+        <p>
+          Die bei der Registrierung oder später von Dir angegebenen personenbezogenen Daten
+          verarbeiten wir nur zu den weiter unten genannten Zwecken. Wir übermitteln sie nicht an
+          Dritte zu weiteren Zwecken, außer:
+        </p>
+        <ul>
+          <li>wir haben Deine ausdrückliche Einwilligung dazu,</li>
+          <li>die Verarbeitung ist zur Abwicklung eines Vertrages mit Dir erforderlich,</li>
+          <li>
+            die Verarbeitung ist zur Erfüllung einer rechtlichen Verpflichtung erforderlich oder
+          </li>
+          <li>
+            die Verarbeitung zur Wahrung berechtigter Interessen erforderlich ist und kein Grund zur
+            Annahme besteht, dass Du ein überwiegendes schutzwürdiges Interesse an der
+            Nichtweitergabe dieser Daten hast.
+          </li>
+        </ul>
+        <h1>Deine Registrierung</h1>
+        <p>
+          Im Sinne der Datenminimierung registrierst Du Dich bei unserer Webanwendung einzig mit
+          Deiner E-Mail-Adresse. Weitere personenbezogene Daten sind für die Registrierung nicht
+          nötig. Die Registrierung ist notwendig, um unser Netzwerk nutzen zu können.
+        </p>
+        <br />
+        <p>
+          Über diese E-Mail-Adresse bist Du uns bekannt und ebenso dient diese als Deine Identität.
+          D.h., alle Rechte, die Du ausübst, hängen mit dieser Identität zusammen und über sie
+          erkennen wir, dass Du wirklich Du bist und nicht ein anderer.
+        </p>
+        <br />
+        <p>
+          In der Kommunikation mit uns spielt die von Dir verwendete E-Mail-Adresse also eine
+          zentrale Rolle. Daher werden wir alle von Dir ausgeübten Rechte und ggf. Wünsche, die Du
+          an uns richtest, immer über Deine E-Mail-Adresse verifizieren. Niemals werden wir auf
+          Basis eines Anrufes oder einer sonstigen Information an Deinem Account etwas ändern, ihn
+          z.B. Löschen oder Stillegen, ohne diese Verifizierung – außer, wir sind durch ein Gesetz
+          dazu gezwungen.
+        </p>
+        <br />
+        <p>
+          Gesichert ist Deine Identität in unserem Netzwerk über ein Passwort, was von Dir selbst
+          vergeben werden muss und jederzeit geändert werden kann. Weitere Daten, wie Dein
+          Pseudonym, ein Avatar-Bildchen oder weitere Angaben, die ggf. auch personenbezogene Daten
+          sein können, vergibst Du selbst. Sie sind für die Registrierung selbst nicht nötig.
+        </p>
+        <h1>Allgemeine Nutzungsinformationen</h1>
+        <p>
+          Beim Abruf unserer Website werden von Deinem Browser Daten übertragen, die für den Abruf
+          und die Übermittlung technisch notwendig sind, zum Beispiel Deine IP-Adresse. Die
+          IP-Adresse kann zum Beispiel dazu dienen, Dich zu identifizieren und zählt daher zu den
+          personenbezogenen Daten.
+        </p>
+        <br />
+        <p>
+          Zusätzlich übermittelt Dein Browser mit jeder Anfrage an unseren Webserver weitere
+          Informationen ungefragt, zum Beispiel Informationen über Dein Betriebssystem oder Deinen
+          Webbrowser, die für eine Abfrage unserer Webseiten überflüssig sind und auch nicht
+          ausgewertet werden. Dies sind keine personenbezogenen Daten und lassen keinen Rückschluss
+          auf Deine Person zu.
+        </p>
+        <br />
+        <p>
+          Letztere Daten werden wir u.U. statistisch auswerten, um für die Nutzer unserer Plattform
+          Statistiken bereit zu stellen oder um unsere Plattform weiter zu optimieren,
+          beispielsweise um sie für besonders oft genutzte Browser oder Betriebssysteme optimal
+          anzupassen.
+        </p>
+        <h1>Löschung bzw. Sperrung</h1>
+        <p>
+          Wir folgen dem Grundsatz der Datenvermeidung und Datensparsamkeit. Daher speichern wir
+          Deine personenbezogenen Daten nur so lange, wie dies zur Erreichung der hier genannten
+          Zwecke erforderlich ist oder wie es die ggf. gesetzlich vorgesehenen Speicherfristen
+          vorsehen. Ist die Frist abgelaufen oder der Zweck nicht mehr gegeben, sperren oder löschen
+          wir diese Daten entsprechend den gesetzlichen Vorschriften.
+        </p>
+        <h1>Log-Files</h1>
+        <p>
+          Unsere Webserver schreiben Protokolle, um ggf. vorkommende Anwendungsfehler erkennen zu
+          können. Diese Protokolle enthalten keine IP-Adressen und werden von uns spätestens nach 7
+          Tagen gelöscht.
+        </p>
+        <h1>Cookies</h1>
+        <p>
+          Wie die meisten anderen Webseiten verwenden auch wir so genannte „Cookies“. Cookies sind
+          kleine Textdateien, die von einem Webserver in Deinem Browser gespeichert werden, um dort
+          bestimmte Informationen zu hinterlegen. Zum Beispiel, dass Du angemeldet bist, dass Du die
+          Website in einer bestimmten Sprache sehen möchtest oder um auf der Website zu navigieren.
+          Diese Daten sind nur in Deinem Browser gespeichert und werden von uns nicht weiter
+          gegeben. Für die Funktionalität unserer Website sind diese Cookies erforderlich. Sie
+          können aber trotzdem jederzeit von Dir gelöscht werden.
+        </p>
+        <br />
+        <p>
+          Desweiteren gibt es sogenannte Drittanbieter-Cookies. Cookies von Drittanbietern sind
+          Cookies, die durch eingebundene Funktionalitäten anderer Websites angelegt werden, zum
+          Beispiel bei Like-Buttons, Landkarten oder Videos-Plugins, obwohl Du nur unsere Website
+          besuchst. Diese Drittanbieter können dann Cookies lesen und speichern, genauso, als wenn
+          Du deren Seite besuchen würdest.
+        </p>
+        <br />
+        <p>
+          Da wir als Social-Network bestimmte Funktionalitäten, wie zum Beispiel eingebettete
+          Videos, für die Nutzer zur Verfügung stellen möchten, kommen wir ohne diese Cookies leider
+          nicht aus. Cookies von Drittanbietern ermöglichen das sogenannte Tracking. D.h., dass der
+          Drittanbieter über Deinen Aufruf unserer Website informiert wird und diese Daten auswerten
+          kann.
+        </p>
+        <br />
+        <p>
+          Auch diese Cookies können jederzeit gelöscht werden. Auch kannst Du im Browser das Setzen
+          von Drittanbietercookies verbieten. Dadurch wird unsere Website aber unter Umständen in
+          Ihrer Funktion eingeschränkt sein. Dein Browser kann auch so eingestellt werden, dass Du
+          über Cookies informiert wirst und das Speichern einzeln bestätigen oder ablehnen kannst.
+          Informationen zu den oft genutzten Browsern findest Du hier:
+        </p>
+        <br />
+        <ul>
+          <li>
+            Firefox:
+            <a
+              href="https://support.mozilla.org/de/kb/cookies-erlauben-und-ablehnen"
+              target="_blank"
+            >
+              https://support.mozilla.org/de/kb/cookies-erlauben-und-ablehnen
+            </a>
+          </li>
+          <li>
+            <strong>Chrome:</strong>
+            <a
+              href="http://support.google.com/chrome/bin/answer.py?hl=de&amp;hlrm=en&amp;answer=95647"
+              target="_blank"
+            >
+              http://support.google.com/chrome/bin/answer.py?hl=de&amp;hlrm=en&amp;answer=95647
+            </a>
+          </li>
+          <li>
+            <strong>Safari:</strong>
+            <a href="https://support.apple.com/kb/ph21411?locale=de_DE" target="_blank">
+              https://support.apple.com/kb/ph21411?locale=de_DE
+            </a>
+          </li>
+          <li>
+            <strong>Opera:</strong>
+            <a href="http://help.opera.com/Windows/10.20/de/cookies.html" target="_blank">
+              http://help.opera.com/Windows/10.20/de/cookies.html
+            </a>
+          </li>
+          <li>
+            <strong>Edge:</strong>
+            <a
+              href="https://privacy.microsoft.com/en-us/windows-10-microsoft-edge-and-privacy"
+              target="_blank"
+            >
+              https://privacy.microsoft.com/en-us/windows-10-microsoft-edge-and-privacy
+            </a>
+          </li>
+        </ul>
+        <h1>Die Öffentlichkeit</h1>
+        <p>
+          Unser Netzwerk und alle darin von Dir oder anderen veröffentlichten Daten stehen der
+          Öffentlichkeit zur Verfügung, solange Inhalte bzw. Funktionen nicht explizit anders
+          gekennzeichnet sind. Überdenke daher, was Du schreibst und wie Du Dich äußerst, denn was
+          einmal in der Öffentlichkeit ist, lässt sich nur schwer wieder zurücknehmen, selbst, wenn
+          Du oder wir es löschen.
+        </p>
+        <h1>Du hast Rechte</h1>
+        <p>
+          Damit Du unsere Webanwendung nutzen kannst, verarbeiten wir u.a. personenbezogene Daten
+          von Dir. Du bist also eine von dieser Verarbeitung „betroffene Person“. Gemäß der
+          europäischen Datenschutzgrundverordnung kannst Du daher uns gegenüber folgende Rechte
+          ausüben:
+        </p>
+        <ul>
+          <li>Auskunft über Deine ggf. bei uns verarbeiteten personenbezogenen Daten,</li>
+          <li>Berichtigung unrichtiger personenbezogener Daten,</li>
+          <li>Löschung Deiner bei uns gespeicherten personenbezogenen Daten,</li>
+          <li>
+            Einschränkung der Datenverarbeitung, sofern wir Deine Daten aufgrund gesetzlicher
+            Pflichten noch nicht löschen dürfen,
+          </li>
+          <li>Widerspruch gegen die Verarbeitung Deiner Daten bei uns und</li>
+          <li>Datenübertragbarkeit</li>
+        </ul>
+        <br />
+        <p>
+          <strong>
+            Sofern Du uns eine Einwilligung zur Verarbeitung Deiner personenbezogenen Daten erteilt
+            hast (bei der Registrierung), kannst Du diese jederzeit mit Wirkung für die Zukunft
+            widerrufen.
+          </strong>
+        </p>
+        <br />
+        <p>
+          <strong>
+            Du kannst Dich auch jederzeit bei einer Aufsichtsbehörde über uns beschweren, solltest
+            Du der Ansicht sein, dass die Verarbeitung Deiner personenbezogenen Daten gegen die
+            europäische Datenschutz-Grundverodnung oder das Bundesdatenschutzgesetz verstößt. Eine
+            Möglichkeit ist hier:
+          </strong>
+        </p>
+        <br />
+        <p>
+          <strong>
+            Landesbeauftragter für Datenschutz und Informationsfreiheit Baden-Württemberg
+          </strong>
+        </p>
+        <p>
+          <a href="https://www.baden-wuerttemberg.datenschutz.de/kontakt/" target="_blank">
+            https://www.baden-wuerttemberg.datenschutz.de/kontakt/
+          </a>
+        </p>
+        <h1>Verwendung von Youtube-Videos</h1>
+        <p>
+          Wir nutzen die Youtube-Einbettungsfunktion zur Anzeige und Wiedergabe von Videos des
+          Anbieters „Youtube“, der zu der Google LLC., 1600 Amphitheatre Parkway, Mountain View, CA
+          94043, USA („Google“) gehört.
+        </p>
+        <br />
+        <p>
+          Dabei wird der erweiterte Datenschutzmodus verwendet, der nach Angaben von Google eine
+          Speicherung von Nutzerinformationen erst bei Wiedergabe des/der Videos in Gang setzt.
+        </p>
+        <br />
+        <p>
+          Wenn Du die Wiedergabe eingebetteter Youtube-Videos startest, setzt der Google „Youtube“
+          Cookies ein, um Informationen über Dein Nutzungsverhalten zu sammeln. „Youtube“ nach
+          dienen diese unter anderem dazu, Videostatistiken zu erfassen, die Nutzerfreundlichkeit zu
+          verbessern und Missbrauch zu unterbinden. Bist Du gleichzeitig bei YouTube eingeloggt,
+          werden diese Informationen Deinem Mitgliedskonto bei YouTube zugeordnet. Wenn Du die
+          Zuordnung mit Deinem Profil bei YouTube nicht wünschst, musst Du Dich vor Aktivierung des
+          Buttons ausloggen. Google speichert Deine Daten (selbst für nicht eingeloggte Nutzer) als
+          Nutzungsprofile und wertet diese aus. Eine solche Auswertung erfolgt insbesondere gemäß
+          Art. 6 Abs. 1 lit.f DSGVO auf Basis der berechtigten Interessen von Google an der
+          Einblendung personalisierter Werbung, Marktforschung und/oder bedarfsgerechten Gestaltung
+          seiner Website. Dir steht ein Widerspruchsrecht zu gegen die Bildung dieser Nutzerprofile,
+          wobei Du Dich zur Ausübung dessen an YouTube richten musst.
+        </p>
+        <br />
+        <p>
+          Unabhängig von einer Wiedergabe der eingebetteten Videos wird bei jedem Aufruf dieser
+          Website eine Verbindung zum Google-Netzwerk „DoubleClick“ aufgenommen, was ohne unseren
+          Einfluss weitere Datenverarbeitungsvorgänge auslösen kann.
+        </p>
+        <br />
+        <p>
+          Google LLC mit Sitz in den USA ist für das us-europäische Datenschutzübereinkommen
+          „Privacy Shield“ zertifiziert, welches die Einhaltung des in der EU geltenden
+          Datenschutzniveaus gewährleistet.
+        </p>
+        <br />
+        <p>
+          Weitere Informationen zum Datenschutz bei „YouTube“ findest Du in der Datenschutzerklärung
+          des Anbieters unter:
+          <a href="https://www.google.de/intl/de/policies/privacy" target="_blank">
+            https://www.google.de/intl/de/policies/privacy
+          </a>
+        </p>
+        <h1>Verwendung von Vimeo-Videos</h1>
+        <p>
+          Wir nutzen auch Plugins von Vimeo der Vimeo, LLC, 555 West 18th Street, New York, New York
+          10011, USA.
+        </p>
+        <p>
+          Rufst du eine Seite auf, die ein solches Plugin eingebunden hat, stellt Dein Browser eine
+          direkte Verbindung zu den Servern von Vimeo her. Durch diese Einbindung erhält Vimeo die
+          Information, dass Du unsere Seite aufgerufen hast, auch wenn Du keinen Vimeo-Account
+          besitzt oder gerade nicht bei Vimeo eingeloggt bist. Deine IP-Adresse und noch einige
+          Daten, die Dein Browser liefert, werden von Deinem Browser direkt an einen Server von
+          Vimeo in die USA übermittelt und dort gespeichert.
+        </p>
+        <p>
+          Wenn Du gerade bei Vimeo eingeloggt bist, kann Vimeo die Nutzung unserer webanwendung
+          Deinem Vimeo-Account zuordnen. Wenn Du das Plugin benutzt, wie z.B. beim Start eines
+          Videos, werden diese Informationen ebenso an einen Server von Vimeo gesendet und dort
+          verarbeitet.
+        </p>
+        <br />
+        <p>
+          Diese Verarbeitungsvorgänge erfolgen gem. Art. 6 Abs. 1 lit. f DSGVO auf Grundlage des
+          berechtigten Interesses von Vimeo an Marktforschung und der bedarfsgerechten Gestaltung
+          des Dienstes.
+        </p>
+        <br />
+        <p>Wenn Du das nicht möchtest, musst Du Dich vorher bei Vimeo ausloggen.</p>
+        <br />
+        <p>
+          Vimeo informiert über den Zweck, Umfang und die weitere Verarbeitung und Nutzung der
+          Daten, sowie Ihre diesbezüglichen Rechte und Einstellungsmöglichkeiten zum Schutz Deiner
+          Privatsphäre in den Datenschutzhinweisen:
+          <a href="https://vimeo.com/privacy" target="_blank">https://vimeo.com/privacy</a>
+        </p>
+        <br />
+        <p>
+          Bei Vimeo-Videos, die bei uns in Beiträgen eingebunden sind, ist das Trackingtool Google
+          Analytics integriert. Auf dieses Tracking seitens Vimeo haben wir leider keinen Einfluss.
+          Google Analytics verwendet für das Tracking „Drittanbieter-Cookies“, wie schon oben
+          beschrieben. Die erhobenen Daten über Deine Benutzung unserer Website werden an einen
+          Server von Google übertragen und dort gespeichert, in der Regel in die USA.
+        </p>
+        <br />
+        <p>
+          Dies erfolgt gem. Art. 6 Abs. 1 lit. f DSGVO auf Grundlage des berechtigten Interesses von
+          Vimeo an der statistischen Analyse des Nutzerverhaltens zu Optimierungs- und
+          Marketingzwecken.
+        </p>
+        <h1>Sicherheit des Web-Zugriffs</h1>
+        <p>
+          Um die Datenübertragung von unserem Webserver zu Dir und umgekehrt zu schützen, verwenden
+          wir eine TLS 1.3 verschlüsselte Verbindung. Dass erkennst Du am grünen Schloss in Deinem
+          Browser bzw. daran, dass Deine URL mit „https“ beginnt, statt mit „http“. So kann niemand
+          mitlesen, was Du siehst oder was Du eingibst.
+        </p>
       </ds-space>
     </ds-container>
   </div>
@@ -14,6 +385,7 @@
 
 <script>
 export default {
+  layout: 'default',
   head() {
     return {
       title: this.$t('site.data-privacy'),


### PR DESCRIPTION
EDIT:

```
    Implement a German-only static data-privacy page

    Okay, so the data privacy section needs to be updated @datenbrei:
    We have two sections mentioning the Vimeo and Youtube plugins. After we
    have the Embeds in place, we have many many more embedded code of 3rd
    parties. Can we simply remove the two sections?

    Also regarding the translations: I would wait until we have functional
    components and we can write translations enriched by markup. Until then
    I think it's sufficient to have German-only data privacy page.
```