### PR TITLE
Get rid of property warnings

### DIFF
--- a/webapp/components/CountTo.vue
+++ b/webapp/components/CountTo.vue
@@ -20,7 +20,7 @@ export default {
   },
   props: {
     startVal: { type: Number, default: 0 },
-    endVal: { type: Number, required: true },
+    endVal: { type: Number, default: 0 },
     duration: { type: Number, default: 3000 },
     autoplay: { type: Boolean, default: true },
     separator: { type: String, default: '.' },

--- a/webapp/components/User/index.vue
+++ b/webapp/components/User/index.vue
@@ -50,7 +50,11 @@
         <ds-flex style="margin-top: -10px">
           <ds-flex-item class="ds-tab-nav-item">
             <ds-space margin="small">
-              <ds-number :count="fanCount" :label="$t('profile.followers')" size="x-large" />
+              <ds-number
+                :count="user.followedByCount"
+                :label="$t('profile.followers')"
+                size="x-large"
+              />
             </ds-space>
           </ds-flex-item>
           <ds-flex-item class="ds-tab-nav-item ds-tab-nav-item-active">
@@ -120,10 +124,6 @@ export default {
     }),
     itsMe() {
       return this.user.slug === this.$store.getters['auth/user'].slug
-    },
-    fanCount() {
-      let count = Number(this.user.followedByCount) || 0
-      return count
     },
     userLink() {
       const { id, slug } = this.user

--- a/webapp/pages/admin/index.vue
+++ b/webapp/pages/admin/index.vue
@@ -7,7 +7,7 @@
             <ds-space margin="small">
               <ds-number :count="0" :label="$t('admin.dashboard.users')" size="x-large" uppercase>
                 <no-ssr slot="count">
-                  <hc-count-to :end-val="statistics.countUsers || 0" />
+                  <hc-count-to :end-val="statistics.countUsers" />
                 </no-ssr>
               </ds-number>
             </ds-space>
@@ -16,7 +16,7 @@
             <ds-space margin="small">
               <ds-number :count="0" :label="$t('admin.dashboard.posts')" size="x-large" uppercase>
                 <no-ssr slot="count">
-                  <hc-count-to :end-val="statistics.countPosts || 0" />
+                  <hc-count-to :end-val="statistics.countPosts" />
                 </no-ssr>
               </ds-number>
             </ds-space>
@@ -30,7 +30,7 @@
                 uppercase
               >
                 <no-ssr slot="count">
-                  <hc-count-to :end-val="statistics.countComments || 0" />
+                  <hc-count-to :end-val="statistics.countComments" />
                 </no-ssr>
               </ds-number>
             </ds-space>
@@ -44,7 +44,7 @@
                 uppercase
               >
                 <no-ssr slot="count">
-                  <hc-count-to :end-val="statistics.countNotifications || 0" />
+                  <hc-count-to :end-val="statistics.countNotifications" />
                 </no-ssr>
               </ds-number>
             </ds-space>
@@ -58,7 +58,7 @@
                 uppercase
               >
                 <no-ssr slot="count">
-                  <hc-count-to :end-val="statistics.countOrganizations || 0" />
+                  <hc-count-to :end-val="statistics.countOrganizations" />
                 </no-ssr>
               </ds-number>
             </ds-space>
@@ -72,7 +72,7 @@
                 uppercase
               >
                 <no-ssr slot="count">
-                  <hc-count-to :end-val="statistics.countProjects || 0" />
+                  <hc-count-to :end-val="statistics.countProjects" />
                 </no-ssr>
               </ds-number>
             </ds-space>
@@ -81,7 +81,7 @@
             <ds-space margin="small">
               <ds-number :count="0" :label="$t('admin.dashboard.invites')" size="x-large" uppercase>
                 <no-ssr slot="count">
-                  <hc-count-to :end-val="statistics.countInvites || 0" />
+                  <hc-count-to :end-val="statistics.countInvites" />
                 </no-ssr>
               </ds-number>
             </ds-space>
@@ -90,7 +90,7 @@
             <ds-space margin="small">
               <ds-number :count="0" :label="$t('admin.dashboard.follows')" size="x-large" uppercase>
                 <no-ssr slot="count">
-                  <hc-count-to :end-val="statistics.countFollows || 0" />
+                  <hc-count-to :end-val="statistics.countFollows" />
                 </no-ssr>
               </ds-number>
             </ds-space>
@@ -99,7 +99,7 @@
             <ds-space margin="small">
               <ds-number :count="0" :label="$t('admin.dashboard.shouts')" size="x-large" uppercase>
                 <no-ssr slot="count">
-                  <hc-count-to :end-val="statistics.countShouts || 0" />
+                  <hc-count-to :end-val="statistics.countShouts" />
                 </no-ssr>
               </ds-number>
             </ds-space>

--- a/webapp/pages/profile/_id/_slug.vue
+++ b/webapp/pages/profile/_id/_slug.vue
@@ -43,14 +43,14 @@
             <ds-flex-item>
               <no-ssr>
                 <ds-number :label="$t('profile.followers')">
-                  <hc-count-to slot="count" :end-val="followedByCount" />
+                  <hc-count-to slot="count" :end-val="user.followedByCount" />
                 </ds-number>
               </no-ssr>
             </ds-flex-item>
             <ds-flex-item>
               <no-ssr>
                 <ds-number :label="$t('profile.following')">
-                  <hc-count-to slot="count" :end-val="Number(user.followingCount) || 0" />
+                  <hc-count-to slot="count" :end-val="user.followingCount" />
                 </ds-number>
               </no-ssr>
             </ds-flex-item>
@@ -308,10 +308,6 @@ export default {
     },
     myProfile() {
       return this.$route.params.id === this.$store.getters['auth/user'].id
-    },
-    followedByCount() {
-      let count = Number(this.user.followedByCount) || 0
-      return count
     },
     user() {
       return this.User ? this.User[0] : {}


### PR DESCRIPTION
If we always choose `0` as the default value for `endVal` in case it is
not given (maybe apollo assigns null when the request is in flight) then
just make `0` the default.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
