### PR TITLE
Configure dbms.security.procedures

### DIFF
--- a/deployment/human-connection/deployment-neo4j.yaml
+++ b/deployment/human-connection/deployment-neo4j.yaml
@@ -32,6 +32,8 @@
             value: 1G
           - name: NEO4J_dbms_memory_heap_max__size
             value: 1G
+          - name: NEO4J_dbms_security_procedures_unrestricted
+            value: "algo.*,apoc.*"
           envFrom:
           - configMapRef:
               name: configmap


### PR DESCRIPTION
Bug:
> apoc.cluster.graph is unavailable because it is sandboxed and has dependencies
> outside of the sandbox. Sandboxing is controlled by the
> dbms.security.procedures.unrestricted setting

See: https://stackoverflow.com/a/48773575

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
