### PR TITLE
Fix expiration dates of JWT and cookie

### DIFF
--- a/backend/src/jwt/encode.js
+++ b/backend/src/jwt/encode.js
@@ -4,7 +4,7 @@ import CONFIG from './../config'
 // Generate an Access Token for the given User ID
 export default function encode(user) {
   const token = jwt.sign(user, CONFIG.JWT_SECRET, {
-    expiresIn: 24 * 60 * 60 * 1000, // one day
+    expiresIn: '1d',
     issuer: CONFIG.GRAPHQL_URI,
     audience: CONFIG.CLIENT_URI,
     subject: user.id.toString(),

--- a/webapp/nuxt.config.js
+++ b/webapp/nuxt.config.js
@@ -271,7 +271,7 @@ module.exports = {
   apollo: {
     tokenName: 'human-connection-token', // optional, default: apollo-token
     cookieAttributes: {
-      expires: 3, // optional, default: 7 (days)
+      expires: 1, // optional, default: 7 (days)
     },
     // includeNodeModules: true, // optional, default: false (this includes graphql-tag for node_modules folder)
 

--- a/webapp/store/auth.js
+++ b/webapp/store/auth.js
@@ -144,10 +144,4 @@ export const actions = {
     commit('SET_TOKEN', null)
     return this.app.$apolloHelpers.onLogout()
   },
-
-  register({ dispatch, commit }, { email, password, inviteCode, invitedByUserId }) {},
-  async patch({ state, commit, dispatch }, data) {},
-  resendVerifySignup({ state, dispatch }) {},
-  resetPassword({ state }, data) {},
-  setNewPassword({ state }, data) {},
 }


### PR DESCRIPTION
This won't fix the bug that can happen in `nuxtServerInit`. However,
according to the docs, we accepted JWT which was valid for 1000 days and
our cookie was valid for 3 days - completely weird.

See:
https://github.com/auth0/node-jsonwebtoken
https://github.com/nuxt-community/apollo-module

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
