### PR TITLE
Fix "cannot read property id of null" in staging

### DIFF
--- a/backend/src/middleware/sentryMiddleware.js
+++ b/backend/src/middleware/sentryMiddleware.js
@@ -14,13 +14,16 @@ if (sentryConfigs.SENTRY_DSN_BACKEND) {
     },
     withScope: (scope, error, context) => {
       scope.setUser({
-        id: context.user.id,
+        id: context.user && context.user.id,
       })
       scope.setExtra('body', context.req.body)
       scope.setExtra('origin', context.req.headers.origin)
       scope.setExtra('user-agent', context.req.headers['user-agent'])
     },
   })
+} else {
+  // eslint-disable-next-line no-console
+  if (process.env.NODE_ENV !== 'test') console.log('Warning: Sentry middleware inactive.')
 }
 
 export default sentryMiddleware


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
I was wondering: Why don't we see AuthenticationErrors on Sentry? Why don't we have waay more spam? Await the incoming spam after this has been merged :wink: 

@datenbrei sb. deleted the user account with `admin` privileges on https://nitro-staging.human-connection.org/. On https://nitro-production.human-connection.org/ you can still log in with an admin account. The "cannot read property id of null" happens if there is an authentication error and sentry middleware is active.

@mattwr18 can you restore staging data please?

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
