### PR TITLE
Increase nginx client max body size, split size legacy migration

### DIFF
--- a/deployment/digital-ocean/https/templates/ingress.template.yaml
+++ b/deployment/digital-ocean/https/templates/ingress.template.yaml
@@ -7,20 +7,21 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     certmanager.k8s.io/issuer: "letsencrypt-staging"
     certmanager.k8s.io/acme-challenge-type: http01
+    nginx.ingress.kubernetes.io/proxy-body-size: 6m
 spec:
   tls:
-  - hosts:
-    # - nitro-mailserver.human-connection.org
-    - nitro-staging.human-connection.org
-    secretName: tls
+    - hosts:
+        # - nitro-mailserver.human-connection.org
+        - nitro-staging.human-connection.org
+      secretName: tls
   rules:
-  - host: nitro-staging.human-connection.org
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: nitro-web
-          servicePort: 3000
+    - host: nitro-staging.human-connection.org
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: nitro-web
+              servicePort: 3000
   # - host: nitro-mailserver.human-connection.org
   #   http:
   #     paths:

--- a/deployment/legacy-migration/maintenance-worker/migration/mongo/.env
+++ b/deployment/legacy-migration/maintenance-worker/migration/mongo/.env
@@ -12,6 +12,6 @@
 # On Windows this resolves to C:\Users\dornhoeschen\AppData\Local\Temp\mongo-export (MinGW)
 EXPORT_PATH='/tmp/mongo-export/'
 EXPORT_MONGOEXPORT_BIN='mongoexport'
-MONGO_EXPORT_SPLIT_SIZE=100
+MONGO_EXPORT_SPLIT_SIZE=4000
 # On Windows use something like this
 # EXPORT_MONGOEXPORT_BIN='C:\Program Files\MongoDB\Server\3.6\bin\mongoexport.exe'


### PR DESCRIPTION
- allows the client to send files at least the size we agreed in the vue-dropzone
- we don't need such a small split size as we don't run it on the remote server

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?

- relates #XXX
-->
- fixes #1405 

