### PR TITLE
Simplify cypress testing on docker

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -1,6 +1,16 @@
 # End-to-End Testing
 
-## Configure cypress
+## Setup with docker
+
+Are you running everything through docker? You're so lucky you don't have to
+setup anything!
+
+Just:
+```
+docker-compose up
+```
+
+## Setup without docker
 
 First, you have to tell cypress how to connect to your local neo4j database
 among other things. You can copy our template configuration and change the new
@@ -11,15 +21,14 @@ Make sure you are at the root level of the project. Then:
 # in the top level folder Human-Connection/
 $ cp cypress.env.template.json cypress.env.json
 ```
-
-## Run Tests
-
-To run the tests, do this:
+To start the services that are required for cypress testing, run this:
 
 ```bash
 # in the top level folder Human-Connection/
 $ yarn cypress:setup
 ```
+
+## Run cypress
 
 After verifying that there are no errors with the servers starting, open another tab in your terminal and run the following command:
 
@@ -29,13 +38,12 @@ $ yarn cypress:run
 
 ![Console output after running cypress test](../.gitbook/assets/grafik%20%281%29.png)
 
-After the test runs, you will also get some video footage of the test run which you can then analyse in more detail.
 
-## Open Interactive Test Console
+### Open Interactive Test Console
 
 If you are like me, you might want to see some visual output. The interactive cypress environment also helps at debugging your tests, you can even time travel between individual steps and see the exact state of the app.
 
-To use this feature, you will still run the `yarn cypress:setup` above, but instead of `yarn cypress:run` open another tab in your terminal and run the following command:
+To use this feature, instead of `yarn cypress:run` you would run the following command:
 
 ```bash
 $ yarn cypress:open

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -16,6 +16,30 @@ services:
       - webapp_node_modules:/nitro-web/node_modules
     command: yarn run dev
     user: root
+  factories:
+    image: humanconnection/nitro-backend:builder
+    build:
+      context: backend
+      target: builder
+    ports:
+      - 4001:4001
+    networks:
+      - hc-network
+    volumes:
+      - ./backend:/nitro-backend
+      - factories_node_modules:/nitro-backend/node_modules
+      - uploads:/nitro-backend/public/uploads
+    depends_on:
+      - neo4j
+    environment:
+      - NEO4J_URI=bolt://neo4j:7687
+      - GRAPHQL_PORT=4000
+      - GRAPHQL_URI=http://localhost:4000
+      - CLIENT_URI=http://localhost:3000
+      - JWT_SECRET=b/&&7b78BF&fv/Vd
+      - MAPBOX_TOKEN=pk.eyJ1IjoiaHVtYW4tY29ubmVjdGlvbiIsImEiOiJjajl0cnBubGoweTVlM3VwZ2lzNTNud3ZtIn0.KZ8KK9l70omjXbEkkbHGsQ
+      - PRIVATE_KEY_PASSPHRASE=a7dsf78sadg87ad87sfagsadg78
+    command: yarn run test:before:seeder
   backend:
     image: humanconnection/nitro-backend:builder
     build:
@@ -42,5 +66,6 @@ services:
 volumes:
   webapp_node_modules:
   backend_node_modules:
+  factories_node_modules:
   neo4j-data:
   uploads:


### PR DESCRIPTION
This should fix our endless debugging

@ogerly all you have to do now is to `docker-compose up`. On your host
machine, you can run `yarn run cypress:open` to run the tests.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
