### PR TITLE
Disable scrolling behind popover

### DIFF
--- a/webapp/assets/styles/imports/_tooltip.scss
+++ b/webapp/assets/styles/imports/_tooltip.scss
@@ -83,6 +83,8 @@
     border-radius: $border-radius-base;
     padding: $space-x-small $space-small;
     box-shadow: $box-shadow-large;
+    overflow: auto;
+    max-height: 73.5vh; // magic! fully visible on mobile, no scrolling on wide screen
   }
 
   @include arrow(5px, "tooltip", $background-color-inverse-soft);

--- a/webapp/assets/styles/main.scss
+++ b/webapp/assets/styles/main.scss
@@ -50,6 +50,11 @@ $easeOut: cubic-bezier(0.19, 1, 0.22, 1);
   background: #fff;
 }
 
+body.dropdown-open {
+  height: 100vh;
+  overflow: hidden;
+}
+
 blockquote {
   display: block;
   padding: 15px 20px 15px 45px;


### PR DESCRIPTION
## 🍰 Pullrequest
This is a quick'n'dirty solution to disable background scrolling when a popover is open. You can test this by opening the notifications dropdown or filter menu.

### Issues
- fixes #1413

### Todo
- [ ] Find/Write a replacement for the [v-tooltip package](https://github.com/Akryum/v-tooltip) to allow for a more elegant solution – not in this PR, though (see https://github.com/Human-Connection/Nitro-Styleguide/issues/151)
