### PR TITLE
1393 fix show less bugginess

### DIFF
--- a/webapp/components/Comment.spec.js
+++ b/webapp/components/Comment.spec.js
@@ -63,6 +63,7 @@ describe('Comment.vue', () => {
         propsData.comment = {
           id: '2',
           contentExcerpt: 'Hello I am a comment content',
+          content: 'Hello I am comment content'
         }
       })
 

--- a/webapp/components/Comment.spec.js
+++ b/webapp/components/Comment.spec.js
@@ -63,7 +63,7 @@ describe('Comment.vue', () => {
         propsData.comment = {
           id: '2',
           contentExcerpt: 'Hello I am a comment content',
-          content: 'Hello I am comment content'
+          content: 'Hello I am comment content',
         }
       })
 

--- a/webapp/components/Comment.vue
+++ b/webapp/components/Comment.vue
@@ -38,18 +38,14 @@
       <div v-show="!openEditCommentMenu">
         <div v-if="isCollapsed" v-html="comment.contentExcerpt" style="padding-left: 40px;" />
         <div
-          v-show="comment.content !== comment.contentExcerpt"
+          v-show="comment.content !== comment.contentExcerpt && comment.content.length > 180"
           style="text-align: right;  margin-right: 20px; margin-top: -12px;"
         >
           <a v-if="isCollapsed" style="padding-left: 40px;" @click="isCollapsed = !isCollapsed">
             {{ $t('comment.show.more') }}
           </a>
         </div>
-        <content-viewer
-          v-if="!isCollapsed"
-          :content="comment.content"
-          style="padding-left: 40px;"
-        />
+        <content-viewer v-if="!isCollapsed" v-html="comment.content" style="padding-left: 40px;" />
         <div style="text-align: right;  margin-right: 20px; margin-top: -12px;">
           <a v-if="!isCollapsed" @click="isCollapsed = !isCollapsed" style="padding-left: 40px; ">
             {{ $t('comment.show.less') }}

--- a/webapp/components/CommentList/CommentList.spec.js
+++ b/webapp/components/CommentList/CommentList.spec.js
@@ -27,7 +27,9 @@ describe('CommentList.vue', () => {
       propsData = {
         post: {
           id: 1,
-          comments: [{ id: 'comment134', contentExcerpt: 'this is a comment', content: 'this is a comment' }],
+          comments: [
+            { id: 'comment134', contentExcerpt: 'this is a comment', content: 'this is a comment' },
+          ],
         },
       }
       store = new Vuex.Store({

--- a/webapp/components/CommentList/CommentList.spec.js
+++ b/webapp/components/CommentList/CommentList.spec.js
@@ -27,7 +27,7 @@ describe('CommentList.vue', () => {
       propsData = {
         post: {
           id: 1,
-          comments: [{ id: 'comment134', contentExcerpt: 'this is a comment' }],
+          comments: [{ id: 'comment134', contentExcerpt: 'this is a comment', content: 'this is a comment' }],
         },
       }
       store = new Vuex.Store({


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?

- relates #XXX
-->
- fixes #1393 

this fixes the bug that the `show more` link is shown when a @mention occurs for comments that are shorter than 180 characters... 
at the moment, we were just checking if there is any difference between content and contentExcerpt, then showing the show more, but for some reason, there is always a difference between comments content longer or shorter than 180 characters

on my local development, the show less is still buggy, because it used the `content-viewer`, which used the editor, but in production it seems to not be an issue.
### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
