### PR TITLE
Fix #1394

### DIFF
--- a/webapp/pages/index.vue
+++ b/webapp/pages/index.vue
@@ -125,12 +125,6 @@ export default {
       return this.$apollo.loading || (this.posts && this.posts.length > 0)
     },
   },
-  watch: {
-    postsFilter() {
-      this.offset = 0
-      this.posts = []
-    },
-  },
   methods: {
     toggleOnlySorting(x) {
       this.offset = 0
@@ -149,8 +143,11 @@ export default {
       }).href
     },
     showMoreContributions() {
+      const { Post: PostQuery } = this.$apollo.queries
+      if (!PostQuery) return // seems this can be undefined on subpages
+
       this.offset += this.pageSize
-      this.$apollo.queries.Post.fetchMore({
+      PostQuery.fetchMore({
         variables: {
           offset: this.offset,
           filter: this.finalFilters,

--- a/webapp/pages/profile/_id/_slug.vue
+++ b/webapp/pages/profile/_id/_slug.vue
@@ -363,8 +363,11 @@ export default {
       this.$apollo.queries.User.refetch()
     },
     showMoreContributions() {
+      const { Post: PostQuery } = this.$apollo.queries
+      if (!PostQuery) return // seems this can be undefined on subpages
+
       this.offset += this.pageSize
-      this.$apollo.queries.Post.fetchMore({
+      PostQuery.fetchMore({
         variables: {
           offset: this.offset,
           filter: this.filter,


### PR DESCRIPTION
It seems that we weren't using the API of `vue-apollo` in the right way.
The `update` callback is to transform the results (e.g. to map between
the server response and a `data` attribute with a different name). For
pagination there is a dedicated procedure called `fetchMore`. See:

* https://vue-apollo.netlify.com/guide/apollo/pagination.html
* https://vue-apollo.netlify.com/guide/components/query.html#query-operations

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #1394 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
