### PR TITLE
Fix test by setting value of the mocked hashtag

### DIFF
--- a/webapp/pages/index.spec.js
+++ b/webapp/pages/index.spec.js
@@ -88,6 +88,8 @@ describe('PostIndex', () => {
     })
 
     it('clears the search when the filter menu emits clearSearch', () => {
+      mocks.$route.query.hashtag = '#samplehashtag'
+      wrapper = Wrapper()
       wrapper.find(FilterMenu).vm.$emit('clearSearch')
       expect(wrapper.vm.hashtag).toBeNull()
     })


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
- The test wasnt testing anything as the hashtag value was defaulting to null
- Fixed by setting value of hashtag to a string and then testing if the clearSearch works
