### PR TITLE
Speed up builds, `docker-compose build --parallel`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ before_install:
   - cp cypress.env.template.json cypress.env.json
 
 install:
-  - docker-compose -f docker-compose.yml -f docker-compose.travis.yml up --build -d
+  - docker-compose -f docker-compose.yml -f docker-compose.travis.yml build --parallel
+  - docker-compose -f docker-compose.yml -f docker-compose.travis.yml up -d
     # avoid "Database constraints have changed after this transaction started"
   - wait-on http://localhost:7474
   - docker-compose exec neo4j db_setup


### PR DESCRIPTION
Found this: https://devops.stackexchange.com/questions/1343/is-it-possible-to-build-docker-images-using-docker-compose-concurrently

Tought: Let's try out immediately

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
