### PR TITLE
Add styleguide as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "styleguide"]
+	path = styleguide
+	url = https://github.com/Human-Connection/Nitro-Styleguide.git

--- a/webapp/nuxt.config.js
+++ b/webapp/nuxt.config.js
@@ -3,7 +3,7 @@ const pkg = require('./package')
 export const envWhitelist = ['NODE_ENV', 'MAPBOX_TOKEN']
 const dev = process.env.NODE_ENV !== 'production'
 
-const styleguidePath = '../Nitro-Styleguide'
+const styleguidePath = '../styleguide'
 const styleguideStyles = process.env.STYLEGUIDE_DEV
   ? [
       `${styleguidePath}/src/system/styles/main.scss`,


### PR DESCRIPTION
## 🍰 Pullrequest
    Add styleguide/ as submodule

    This should make new contributors aware that the Styleguide exists and
    maybe maybe even encourage people to contribute to the Styleguide.

    Also this enabled `yarn run dev:styleguide` to build the `webapp/` along
    with the styleguide.


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [ ] If we decide to merge this PR, we should setup dependabot to automatically update the submodule. The policy should be to automatically merge a new commit of the submodule, because it's the same team that reviews PRs in [this repo](https://github.com/Human-Connection/Nitro-Styleguide) as well in [this repo](https://github.com/Human-Connection/Human-Connection).
