### PR TITLE
Relase without any artifacts

### DIFF
--- a/scripts/github_release.sh
+++ b/scripts/github_release.sh
@@ -4,7 +4,7 @@ RELEASE_DIR="${ROOT_DIR}/release"
 
 VERSION=$(<$ROOT_DIR/VERSION)
 
-mkdir -p $RELEASE_DIR
+# mkdir -p $RELEASE_DIR
 
 # The following command part produces 854M on my machine
 # apps=(nitro-web nitro-backend neo4j maintenance-worker maintenance)
@@ -13,10 +13,4 @@ mkdir -p $RELEASE_DIR
 #   docker image save "humanconnection/${app}:latest" | gzip > "${RELEASE_DIR}/${app}.${VERSION}.tar.gz"
 # done
 
-# Use something smaller instead
-git archive --format tar HEAD:backend | gzip > "${RELEASE_DIR}/backend.${VERSION}.tar.gz"
-git archive --format tar HEAD:webapp  | gzip > "${RELEASE_DIR}/webapp.${VERSION}.tar.gz"
-git archive --format zip HEAD:backend > "${RELEASE_DIR}/backend.${VERSION}.zip"
-git archive --format zip HEAD:webapp  > "${RELEASE_DIR}/webapp.${VERSION}.zip"
-
-ghr -soft "${VERSION}" "${RELEASE_DIR}"
+ghr -soft "${VERSION}"


### PR DESCRIPTION
I contributed to `ghr` here:
https://github.com/tcnksm/ghr/pull/118

Now after `ghr` does not need any artifacts to create a file, we can
stop uploading archives. (Use the default archives provided by Github)

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
