### PR TITLE
Exclude broken maintenance-worker docker image

### DIFF
--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -4,14 +4,13 @@ DOCKER_CLI_EXPERIMENTAL=enabled
 # BUILD_COMMIT=${TRAVIS_COMMIT:-$(git rev-parse HEAD)}
 
 IFS='.' read -r major minor patch < $ROOT_DIR/VERSION
-apps=(nitro-web nitro-backend neo4j maintenance-worker maintenance)
+apps=(nitro-web nitro-backend neo4j maintenance)
 tags=(latest $major $major.$minor $major.$minor.$patch)
 
 # These three docker images have already been built by now:
 # docker build --build-arg BUILD_COMMIT=$BUILD_COMMIT --target production -t humanconnection/nitro-backend:latest $ROOT_DIR/backend
 # docker build --build-arg BUILD_COMMIT=$BUILD_COMMIT --target production -t humanconnection/nitro-web:latest $ROOT_DIR/webapp
 # docker build --build-arg BUILD_COMMIT=$BUILD_COMMIT -t humanconnection/neo4j:latest $ROOT_DIR/neo4j
-docker build -t humanconnection/maintenance-worker:latest $ROOT_DIR/deployment/legacy-migration/maintenance-worker
 docker build -t humanconnection/maintenance:latest $ROOT_DIR/webapp/ -f $ROOT_DIR/webapp/Dockerfile.maintenance
 
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin


### PR DESCRIPTION
The Dockerfile is still using `apk` instead of `apt-get` (Debian slim).
So that's why our build server never successfully pushed the
`maintenance-worker` image.

![Screenshot - 2019-09-18T144805 349](https://user-images.githubusercontent.com/2110676/65153596-50c3c680-da2a-11e9-9e79-aade9f8bc8d2.png)

Building the docker image simply broke on that day and none of us noticed. Apparently nobody tried to do the backup from within the docker container.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [ ] Maybe we want to delete that Dockerfile altogether? Devops, your opinion @Tirokk @mattwr18 ?
