### PR TITLE
Fix styling issue in comments list

### DIFF
--- a/webapp/components/CommentList/CommentList.vue
+++ b/webapp/components/CommentList/CommentList.vue
@@ -16,7 +16,7 @@
       </span>
     </h3>
     <ds-space margin-bottom="large" />
-    <div v-if="post.comments && post.comments.length" id="comments">
+    <div v-if="post.comments && post.comments.length" id="comments" class="comments">
       <comment
         v-for="comment in post.comments"
         :key="comment.id"


### PR DESCRIPTION
- add back class comments which adds spaces between comments

![Screenshot from 2019-09-19 16-00-29](https://user-images.githubusercontent.com/26943915/65250896-9ea60080-daf6-11e9-8e9b-9fc1d99c2c1b.png)
