### PR TITLE
Fix intermittent failing test

### DIFF
--- a/backend/src/schema/resolvers/notifications.spec.js
+++ b/backend/src/schema/resolvers/notifications.spec.js
@@ -214,7 +214,7 @@ describe('given some notifications', () => {
           })
           await expect(
             query({ query: notificationQuery, variables: { ...variables, read: false } }),
-          ).resolves.toEqual(expected)
+          ).resolves.toMatchObject(expected)
         })
 
         describe('if a resource gets deleted', () => {


### PR DESCRIPTION
- the test was regularly failing our build
- change from toEqual to toMatchObject since there is more info coming
back, like errors, etc...