### PR TITLE
[WIP] Fix interactive email

### DIFF
--- a/backend/src/middleware/email/templates/resetPassword.html
+++ b/backend/src/middleware/email/templates/resetPassword.html
@@ -19,7 +19,7 @@
   <![endif]-->
 
   <!--[if !mso]><!-->
-  <link href='https://fonts.googleapis.com/css?family=Lato:400,700' rel='stylesheet' type='text/css'>
+  <link href="https://fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet" type="text/css">
   <!--<![endif]-->
 
   <!-- CSS RESETS -->
@@ -145,8 +145,16 @@
 
   <!-- LANGUAGE TOGGLE -->
   <style>
-    .toggle+label {
-      display: inline-block;
+    .interactivity-supported:checked~.toggle-label {
+      display: inline-block !important;
+    }
+
+    .interactivity-supported:checked~.fallback {
+      display: none;
+    }
+
+    .toggle-label {
+      display: none;
       height: 40px;
       padding: 0 12px;
       margin-top: 40px;
@@ -157,23 +165,23 @@
       cursor: pointer;
     }
 
-    .toggle+label:hover {
+    .toggle-label:hover {
       background-color: #bee876;
     }
 
-    .toggle:checked+label {
+    .toggle:checked+.toggle-label {
       background-color: #19c243;
       color: white;
     }
 
-    .toggle-english+label {
+    .toggle-english+.toggle-label {
       border-bottom-right-radius: 50px;
       border-top-right-radius: 50px;
       border-left: none;
       margin-left: -2px;
     }
 
-    .toggle-german+label {
+    .toggle-german+.toggle-label {
       border-bottom-left-radius: 50px;
       border-top-left-radius: 50px;
       border-right: none;
@@ -214,11 +222,14 @@
       <![endif]-->
 
       <!-- LANGUAGE TOGGLE -->
+      <input type="radio" name="interactivity-supported" class="interactivity-supported" style="display: none;"
+        checked="checked" />
       <input type="radio" name="language" class="toggle toggle-german" style="display: none;" id="toggle-german"
         checked="checked">
-      <label for="toggle-german">Deutsch</label>
+      <label for="toggle-german" class="toggle-label">Deutsch</label>
       <input type="radio" name="language" class="toggle toggle-english" style="display:none;" id="toggle-english">
-      <label for="toggle-english">English</label>
+      <label for="toggle-english" class="toggle-label">English</label>
+      <p class="fallback" style="color: #17b53e; font-family: Lato, sans-serif;">English version below!</p>
       <p style="margin: 0;"></p>
 
       <!-- Email Body German : BEGIN -->

--- a/backend/src/middleware/email/templates/resetPassword.html
+++ b/backend/src/middleware/email/templates/resetPassword.html
@@ -222,6 +222,7 @@
       <![endif]-->
 
       <!-- LANGUAGE TOGGLE -->
+      <!--[if !mso]><!-->
       <input type="radio" name="interactivity-supported" class="interactivity-supported" style="display: none;"
         checked="checked" />
       <input type="radio" name="language" class="toggle toggle-german" style="display: none;" id="toggle-german"
@@ -229,6 +230,7 @@
       <label for="toggle-german" class="toggle-label">Deutsch</label>
       <input type="radio" name="language" class="toggle toggle-english" style="display:none;" id="toggle-english">
       <label for="toggle-english" class="toggle-label">English</label>
+      <!--<![endif]-->
       <p class="fallback" style="color: #17b53e; font-family: Lato, sans-serif;">English version below!</p>
       <p style="margin: 0;"></p>
 

--- a/backend/src/middleware/email/templates/signup.html
+++ b/backend/src/middleware/email/templates/signup.html
@@ -19,7 +19,7 @@
   <![endif]-->
 
   <!--[if !mso]><!-->
-  <link href='https://fonts.googleapis.com/css?family=Lato:400,700' rel='stylesheet' type='text/css'>
+  <link href="https://fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet" type="text/css">
   <!--<![endif]-->
 
   <!-- CSS RESETS -->

--- a/backend/src/middleware/email/templates/signup.html
+++ b/backend/src/middleware/email/templates/signup.html
@@ -145,8 +145,16 @@
 
   <!-- LANGUAGE TOGGLE -->
   <style>
-    .toggle+label {
-      display: inline-block;
+    .interactivity-supported:checked~.toggle-label {
+      display: inline-block !important;
+    }
+
+    .interactivity-supported:checked~.fallback {
+      display: none;
+    }
+
+    .toggle-label {
+      display: none;
       height: 40px;
       padding: 0 12px;
       margin-top: 40px;
@@ -157,23 +165,23 @@
       cursor: pointer;
     }
 
-    .toggle+label:hover {
+    .toggle-label:hover {
       background-color: #bee876;
     }
 
-    .toggle:checked+label {
+    .toggle:checked+.toggle-label {
       background-color: #19c243;
       color: white;
     }
 
-    .toggle-english+label {
+    .toggle-english+.toggle-label {
       border-bottom-right-radius: 50px;
       border-top-right-radius: 50px;
       border-left: none;
       margin-left: -2px;
     }
 
-    .toggle-german+label {
+    .toggle-german+.toggle-label {
       border-bottom-left-radius: 50px;
       border-top-left-radius: 50px;
       border-right: none;
@@ -224,11 +232,16 @@
       <![endif]-->
 
       <!-- LANGUAGE TOGGLE -->
+      <!--[if !mso]><!-->
+      <input type="radio" name="interactivity-supported" class="interactivity-supported" style="display: none;"
+        checked="checked" />
       <input type="radio" name="language" class="toggle toggle-german" style="display: none;" id="toggle-german"
         checked="checked">
-      <label for="toggle-german">Deutsch</label>
+      <label for="toggle-german" class="toggle-label">Deutsch</label>
       <input type="radio" name="language" class="toggle toggle-english" style="display:none;" id="toggle-english">
-      <label for="toggle-english">English</label>
+      <label for="toggle-english" class="toggle-label">English</label>
+      <!--<![endif]-->
+      <p class="fallback" style="color: #17b53e; font-family: Lato, sans-serif;">English version below!</p>
       <p style="margin: 0;"></p>
 
       <!-- Email Body German : BEGIN -->

--- a/backend/src/middleware/email/templates/wrongAccount.html
+++ b/backend/src/middleware/email/templates/wrongAccount.html
@@ -19,7 +19,7 @@
   <![endif]-->
 
   <!--[if !mso]><!-->
-  <link href='https://fonts.googleapis.com/css?family=Lato:400,700' rel='stylesheet' type='text/css'>
+  <link href="https://fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet" type="text/css">
   <!--<![endif]-->
 
   <!-- CSS RESETS -->

--- a/backend/src/middleware/email/templates/wrongAccount.html
+++ b/backend/src/middleware/email/templates/wrongAccount.html
@@ -145,8 +145,16 @@
 
   <!-- LANGUAGE TOGGLE -->
   <style>
-    .toggle+label {
-      display: inline-block;
+    .interactivity-supported:checked~.toggle-label {
+      display: inline-block !important;
+    }
+
+    .interactivity-supported:checked~.fallback {
+      display: none;
+    }
+
+    .toggle-label {
+      display: none;
       height: 40px;
       padding: 0 12px;
       margin-top: 40px;
@@ -157,23 +165,23 @@
       cursor: pointer;
     }
 
-    .toggle+label:hover {
+    .toggle-label:hover {
       background-color: #bee876;
     }
 
-    .toggle:checked+label {
+    .toggle:checked+.toggle-label {
       background-color: #19c243;
       color: white;
     }
 
-    .toggle-english+label {
+    .toggle-english+.toggle-label {
       border-bottom-right-radius: 50px;
       border-top-right-radius: 50px;
       border-left: none;
       margin-left: -2px;
     }
 
-    .toggle-german+label {
+    .toggle-german+.toggle-label {
       border-bottom-left-radius: 50px;
       border-top-left-radius: 50px;
       border-right: none;
@@ -214,11 +222,16 @@
       <![endif]-->
 
       <!-- LANGUAGE TOGGLE -->
+      <!--[if !mso]><!-->
+      <input type="radio" name="interactivity-supported" class="interactivity-supported" style="display: none;"
+        checked="checked" />
       <input type="radio" name="language" class="toggle toggle-german" style="display: none;" id="toggle-german"
         checked="checked">
-      <label for="toggle-german">Deutsch</label>
+      <label for="toggle-german" class="toggle-label">Deutsch</label>
       <input type="radio" name="language" class="toggle toggle-english" style="display:none;" id="toggle-english">
-      <label for="toggle-english">English</label>
+      <label for="toggle-english" class="toggle-label">English</label>
+      <!--<![endif]-->
+      <p class="fallback" style="color: #17b53e; font-family: Lato, sans-serif;">English version below!</p>
       <p style="margin: 0;"></p>
 
       <!-- Email Body German : BEGIN -->


### PR DESCRIPTION
## 🍰 Pullrequest
- hides toggle button in outlook
- hides toggle button when `radio input` is not supported
- displays emails in both languages when toggle button is not supported
- displays fallback message: "English version below"

### Issues
- fixes #1656

### Todo
- [ ] Test in Outlook on Windows
- [ ] Test in Webmail clients – @datenbrei maybe you could help with this?
