### PR TITLE
Remove repetitive labels from emote button

### DIFF
--- a/webapp/components/EmotionsButton/EmotionsButton.vue
+++ b/webapp/components/EmotionsButton/EmotionsButton.vue
@@ -9,7 +9,6 @@
       <p style="display: inline" :key="PostsEmotionsCountByEmotion[emotion]">
         {{ PostsEmotionsCountByEmotion[emotion] }}x
       </p>
-      {{ $t('contribution.emotions-label.emoted') }}
     </div>
   </div>
 </template>

--- a/webapp/locales/de.json
+++ b/webapp/locales/de.json
@@ -483,8 +483,7 @@
       "happy": "Glücklich",
       "surprised": "Erstaunt",
       "cry": "Zum Weinen",
-      "angry": "Verärgert",
-      "emoted": "angegeben"
+      "angry": "Verärgert"
     },
     "category": {
       "name": {

--- a/webapp/locales/en.json
+++ b/webapp/locales/en.json
@@ -484,8 +484,7 @@
       "happy": "Happy",
       "surprised": "Surprised",
       "cry": "Cry",
-      "angry": "Angry",
-      "emoted": "emoted"
+      "angry": "Angry"
     },
     "category": {
       "name": {


### PR DESCRIPTION
Our dear @Hardy-Peaceglobal mentioned that when he had a look on the app
on my mobile.

## 🍰 Pullrequest

![Screenshot - 2019-09-24T120226 241](https://user-images.githubusercontent.com/2110676/65502562-4fc7e480-dec3-11e9-85cb-6bce97ccb736.png)


**Before**

![Screenshot - 2019-09-24T120058 185](https://user-images.githubusercontent.com/2110676/65502244-b567a100-dec2-11e9-9c2e-3ad9abc9b457.png)


Maybe we can keep the translation for "Shouted" (I see it only once).

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
