### PR TITLE
docs: moves storybook into webapp/README.md

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -90,41 +90,6 @@ $ yarn run db:reset
 {% endtab %}
 {% endtabs %}
 
-### Storybook
-
-We encourage contributors to use Storybook to test out new components in an isolated way, and benefit from its many features.
-See the docs for live examples and answers to FAQ, among other helpful information. ![Storybook docs](https://storybook.js.org/docs/basics/introduction/)
-
-{% tabs %}
-{% tab title="Docker" %}
-
-After you have started the application following the instructions above, in another terminal run:
-
-```bash
-$ docker-compose exec webapp yarn storybook
-```
-The output should look similar to this:
-
-![Storybook output](../.gitbook/assets/storybook-output.png)
-
-Click on the link http://localhost:3002/ to open the browser to your interactive storybook.
-
-{% endtab %}
-
-{% tab title="Without Docker" %}
-Run the following command: 
-
-```bash
-# in webapp/
-yarn storybook
-```
-
-Open http://localhost:3002/ in your browser
-
-{% endtab %}
-{% endtabs %}
-
-
 # Testing
 
 **Beware**: We have no multiple database setup at the moment. We clean the

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -33,6 +33,42 @@ $ yarn build
 $ yarn start
 ```
 
+### Storybook
+
+We encourage contributors to use Storybook to test out new components in an isolated way, and benefit from its many features.
+See the docs for live examples and answers to FAQ, among other helpful information. ![Storybook docs](https://storybook.js.org/docs/basics/introduction/)
+
+{% tabs %}
+{% tab title="Docker" %}
+
+After you have started the application following the instructions above, in another terminal run:
+
+```bash
+$ docker-compose exec webapp yarn storybook
+```
+The output should look similar to this:
+
+![Storybook output](../.gitbook/assets/storybook-output.png)
+
+Click on the link http://localhost:3002/ to open the browser to your interactive storybook.
+
+{% endtab %}
+
+{% tab title="Without Docker" %}
+Run the following command:
+
+```bash
+# in webapp/
+yarn storybook
+```
+
+Open http://localhost:3002/ in your browser
+
+{% endtab %}
+{% endtabs %}
+
+
+
 ## Styleguide
 
 All reusable Components \(for example avatar\) should be done inside the [Nitro-Styleguide](https://github.com/Human-Connection/Nitro-Styleguide) repository.


### PR DESCRIPTION
It makes much more sense to put it under the webapp's README than backend.

FYI: @mattwr18

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
