### PR TITLE
fix email middleware transport config

### DIFF
--- a/backend/src/middleware/email/emailMiddleware.js
+++ b/backend/src/middleware/email/emailMiddleware.js
@@ -21,7 +21,7 @@ if (!hasEmailConfig) {
     const transporter = nodemailer.createTransport({
       host: CONFIG.SMTP_HOST,
       port: CONFIG.SMTP_PORT,
-      ignoreTLS: CONFIG.SMTP_IGNORE_TLS,
+      ignoreTLS: CONFIG.SMTP_IGNORE_TLS === 'true',
       secure: false, // true for 465, false for other ports
       auth: hasAuthData && {
         user: CONFIG.SMTP_USERNAME,


### PR DESCRIPTION
## 🍰 Pullrequest
Set `ignoreTLS` option to true only when env variable `SMTP_IGNORE_TLS` is set to true.
Any other value will set the option to false.

### Issues
- None

### Todo
- [X] None
