### PR TITLE
Max aspect ratio of 1:1 for Post index page

### DIFF
--- a/webapp/pages/post/_id/_slug/index.vue
+++ b/webapp/pages/post/_id/_slug/index.vue
@@ -197,7 +197,7 @@ export default {
 
     .ds-card-image {
       img {
-        height: 300px;
+        max-height: 710px;
         object-fit: cover;
         object-position: center;
       }


### PR DESCRIPTION
- we are currently enforcing a 1:1 max ratio on the root path and would
like to maintain consistency


