### PR TITLE
fix: search for email case-insensitively

### DIFF
--- a/webapp/pages/admin/users.spec.js
+++ b/webapp/pages/admin/users.spec.js
@@ -49,6 +49,12 @@ describe('Users', () => {
           expect(wrapper.vm.email).toEqual('email@example.org')
           expect(wrapper.vm.filter).toBe(null)
         })
+
+        it('email address is case-insensitive', async () => {
+          const wrapper = await searchAction(Wrapper(), { query: 'eMaiL@example.org' })
+          expect(wrapper.vm.email).toEqual('email@example.org')
+          expect(wrapper.vm.filter).toBe(null)
+        })
       })
 
       describe('query is just text', () => {

--- a/webapp/pages/admin/users.vue
+++ b/webapp/pages/admin/users.vue
@@ -170,7 +170,7 @@ export default {
       this.offset = 0
       const { query } = formData
       if (isemail.validate(query)) {
-        this.email = query
+        this.email = query.toLowerCase()
         this.filter = null
       } else {
         this.email = null


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fix #1645 

### Fun fact

The only uppercase email address that we have is:
`wegenVersuchterScriptInjectionBlockiert@roschaefer.de`

:laughing: 

So, a year ago, I updated this email address manually to stop a user from logging in again.
