### PR TITLE
1997 fix performance issue with pinned post

### DIFF
--- a/backend/src/schema/resolvers/posts.js
+++ b/backend/src/schema/resolvers/posts.js
@@ -234,6 +234,7 @@ export default {
         const deletePreviousRelationsResponse = await transaction.run(
           `
           MATCH (:User)-[previousRelations:PINNED]->(post:Post)
+          REMOVE post.pinned
           DELETE previousRelations
           RETURN post
         `,
@@ -248,6 +249,7 @@ export default {
             MATCH (user:User {id: $userId}) WHERE user.role = 'admin'
             MATCH (post:Post {id: $params.id})
             MERGE (user)-[pinned:PINNED {createdAt: toString(datetime())}]->(post)
+            SET post.pinned = true
             RETURN post, pinned.createdAt as pinnedAt
          `,
           { userId, params },
@@ -276,6 +278,7 @@ export default {
         const unpinPostTransactionResponse = await transaction.run(
           `
           MATCH (:User)-[previousRelations:PINNED]->(post:Post {id: $params.id})
+          REMOVE post.pinned
           DELETE previousRelations
           RETURN post
         `,
@@ -293,7 +296,7 @@ export default {
   },
   Post: {
     ...Resolver('Post', {
-      undefinedToNull: ['activityId', 'objectId', 'image', 'language', 'pinnedAt'],
+      undefinedToNull: ['activityId', 'objectId', 'image', 'language', 'pinnedAt', 'pinned'],
       hasMany: {
         tags: '-[:TAGGED]->(related:Tag)',
         categories: '-[:CATEGORIZED]->(related:Category)',

--- a/backend/src/schema/types/type/Post.gql
+++ b/backend/src/schema/types/type/Post.gql
@@ -1,3 +1,37 @@
+enum _PostOrdering {
+  id_asc
+  id_desc
+  activityId_asc
+  activityId_desc
+  objectId_asc
+  objectId_desc
+  title_asc
+  title_desc
+  slug_asc
+  slug_desc
+  content_asc
+  content_desc
+  contentExcerpt_asc
+  contentExcerpt_desc
+  image_asc
+  image_desc
+  visibility_asc
+  visibility_desc
+  deleted_asc
+  deleted_desc
+  disabled_asc
+  disabled_desc
+  createdAt_asc
+  createdAt_desc
+  updatedAt_asc
+  updatedAt_desc
+  language_asc
+  language_desc
+  pinned_asc
+  pinned_desc
+}
+
+
 type Post {
   id: ID!
   activityId: String
@@ -12,6 +46,7 @@ type Post {
   visibility: Visibility
   deleted: Boolean
   disabled: Boolean
+  pinned: Boolean
   disabledBy: User @relation(name: "DISABLED", direction: "IN")
   createdAt: String
   updatedAt: String

--- a/webapp/pages/index.vue
+++ b/webapp/pages/index.vue
@@ -205,7 +205,7 @@ export default {
         return {
           filter: this.finalFilters,
           first: this.pageSize,
-          orderBy: ['pinnedAt_asc', this.orderBy],
+          orderBy: ['pinned_asc', this.orderBy],
           offset: 0,
         }
       },

--- a/webapp/pages/profile/_id/_slug.vue
+++ b/webapp/pages/profile/_id/_slug.vue
@@ -473,7 +473,7 @@ export default {
           filter: this.filter,
           first: this.pageSize,
           offset: 0,
-          orderBy: ['pinnedAt_asc', 'createdAt_desc'],
+          orderBy: 'createdAt_desc',
         }
       },
       update({ profilePagePosts }) {


### PR DESCRIPTION
## 🍰 Pullrequest

    fix: performance issue with ordering

    @mattwr18 @aonomike
    You must never `ORDER BY` a property with a `@cypher` directive. Reason:
    The order by performance will be terribly poor.

    See my issue:
    https://github.com/neo4j-graphql/neo4j-graphql-js/issues/239
    And my PR:
    https://github.com/neo4j-graphql/neo4j-graphql-js/pull/247

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #1997 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
