### PR TITLE
[WIP] [Systems-Development-and-Frameworks] Storybook for reported content 

### DIFF
--- a/webapp/components/ReportedContent/ReportedContent.spec.js
+++ b/webapp/components/ReportedContent/ReportedContent.spec.js
@@ -1,0 +1,52 @@
+// import { mount } from '@vue/test-utils'
+// import ReportedContent from './ReportedContent.vue'
+
+let resource // eslint-disable-line no-unused-vars
+
+/**
+ * This file is just a sketch. Feel free to change it as needed.
+ */
+
+describe('ReportedContent', () => {
+  describe('given a post', () => {
+    beforeEach(() => {
+      resource = {
+        /* ? */
+      }
+    })
+
+    it.todo('links to the post')
+  })
+
+  describe('given a comment', () => {
+    beforeEach(() => {
+      resource = {
+        /* ? */
+      }
+    })
+
+    it.todo('links to the post of the comment')
+  })
+
+  describe('given the resource is not disabled', () => {
+    beforeEach(() => {
+      resource = {
+        disabled: false,
+        // ...
+      }
+    })
+
+    it.todo('shows a dash in the column "Disabled by"')
+  })
+
+  describe('given the resource is disabled', () => {
+    beforeEach(() => {
+      resource = {
+        disabled: true,
+        // ...
+      }
+    })
+
+    it.todo('shows who disabled the content')
+  })
+})

--- a/webapp/components/ReportedContent/ReportedContent.story.js
+++ b/webapp/components/ReportedContent/ReportedContent.story.js
@@ -1,0 +1,59 @@
+import { storiesOf } from '@storybook/vue'
+import { withA11y } from '@storybook/addon-a11y'
+import helpers from '~/storybook/helpers'
+import {
+  onePostReportedTwoTimes,
+  reportedPostDisabledByModerator,
+} from './ReportedContent.story/data.js'
+
+import ReportedContent from './ReportedContent.vue'
+
+helpers.init()
+
+const reportedPost = {}
+const reportedComment = {}
+const reportedUser = {}
+
+storiesOf('ReportedContent', module)
+  .addDecorator(withA11y)
+  .addDecorator(helpers.layout)
+  .add('post', () => ({
+    components: { ReportedContent },
+    store: helpers.store,
+    data: () => ({
+      resource: reportedPost,
+    }),
+    template: '<reported-content :resource="resource" />',
+  }))
+  .add('comment', () => ({
+    components: { ReportedContent },
+    store: helpers.store,
+    data: () => ({
+      resource: reportedComment,
+    }),
+    template: '<reported-content :resource="resource" />',
+  }))
+  .add('user', () => ({
+    components: { ReportedContent },
+    store: helpers.store,
+    data: () => ({
+      resource: reportedUser,
+    }),
+    template: '<reported-content :resource="resource" />',
+  }))
+  .add('same resource reported multiple times', () => ({
+    components: { ReportedContent },
+    store: helpers.store,
+    data: () => ({
+      resource: onePostReportedTwoTimes,
+    }),
+    template: '<reported-content :resource="resource" />',
+  }))
+  .add('all moderator decision are displayed', () => ({
+    components: { ReportedContent },
+    store: helpers.store,
+    data: () => ({
+      resource: reportedPostDisabledByModerator,
+    }),
+    template: '<reported-content :resource="resource" />',
+  }))

--- a/webapp/components/ReportedContent/ReportedContent.story/data.js
+++ b/webapp/components/ReportedContent/ReportedContent.story/data.js
@@ -1,0 +1,98 @@
+export const onePostReportedTwoTimes = {
+  type: 'Post',
+  user: null,
+  comment: null,
+  post: {
+    id: '291fef1b-c7ff-402f-a6eb-e4af182e0917',
+    slug: 'vento',
+    title: 'Vento',
+    disabled: false,
+    deleted: false,
+    author: {
+      id: 'u3',
+      slug: 'jenny-rostock',
+      name: 'Jenny Rostock',
+      disabled: false,
+      deleted: false,
+    },
+    disabledBy: null,
+  },
+  log: [
+    {
+      type: 'REPORTED',
+      createdAt: '2019-10-22T10:23:39.952Z',
+      reasonCategory: 'intentional_intimidation_stalking_persecution',
+      reasonDescription: '',
+      submitter: {
+        id: 'u5',
+        slug: 'dewey',
+        name: 'Dewey',
+        disabled: false,
+        deleted: false,
+      },
+    },
+    {
+      type: 'REPORTED',
+      createdAt: '2019-10-22T10:23:15.373Z',
+      reasonCategory: 'intentional_intimidation_stalking_persecution',
+      reasonDescription: '',
+      submitter: {
+        id: 'u4',
+        slug: 'huey',
+        name: 'Huey',
+        disabled: false,
+        deleted: false,
+      },
+    },
+  ],
+}
+
+export const reportedPostDisabledByModerator = {
+  createdAt: '2019-10-22T19:13:49.281Z',
+  type: 'Post',
+  user: null,
+  comment: null,
+  post: {
+    id: 'p1',
+    slug: 'quam-est-expedita-sunt-corporis-dolorem-minus',
+    title: 'Quam est expedita sunt corporis dolorem minus.',
+    disabled: true,
+    deleted: false,
+    author: {
+      id: 'u2',
+      slug: 'bob-der-baumeister',
+      name: 'Bob der Baumeister',
+      disabled: false,
+      deleted: false,
+    },
+    disabledBy: {
+      id: 'u1',
+      slug: 'peter-lustig',
+      name: 'Peter Lustig',
+      disabled: false,
+      deleted: false,
+    },
+  },
+  log: [
+    {
+      type: 'REPORTED',
+      reasonCategory: 'discrimination_etc',
+      reasonDescription: 'This post is bigoted',
+      submitter: {
+        id: 'u4',
+        slug: 'huey',
+        name: 'Huey',
+        disabled: false,
+        deleted: false,
+      },
+    },
+    {
+      type: 'DISABLED',
+      moderator: {
+        id: 'u1',
+        slug: 'peter-lustig',
+        name: 'Peter Lustig',
+      },
+    },
+  ],
+}

--- a/webapp/components/ReportedContent/ReportedContent.vue
+++ b/webapp/components/ReportedContent/ReportedContent.vue
@@ -1,0 +1,7 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+export default {}
+</script>


### PR DESCRIPTION
## 🍰 Pullrequest


This is the new exercise for the course "Systems Development and Frameworks". As a user you can report content that violates the community guidelines. It will show up in such a list:

![Screenshot - 2019-10-22T214308 150](https://user-images.githubusercontent.com/2110676/67325021-bff27600-f514-11e9-984b-3899594dc957.png)

What we didn't thought of is that multiple users could report the same thing. So a moderator should see all reports grouped by resource, e.g. one post and a list of all users who reported the post and when.

Relates to #1710 .

#### See moderation page:

1. Visit https://nitro-staging.human-connection.org/
2. Log in as `moderator@example.org` and password `1234`.
3. Click on the avatar menu and choose `Moderation`.

#### Where is the code that renders the list?

It is here: https://github.com/Human-Connection/Human-Connection/blob/master/webapp/pages/moderation/index.vue

#### How can I report someting?

1. Visit https://nitro-staging.human-connection.org/
2. Log in as any user, you can choose `huey@example.org` or `dewey@example.org` etc. and password `1234`
3. Click on the context menu of a post or comment or the context menu on the user profile page. You must not be this user or must not be the author of this post or comment.

###  Task 1: Refactor

All the code which is relevant to show a single line in the table should be moved into this component:

https://github.com/Human-Connection/Human-Connection/blob/storybook_for_reported_content/webapp/components/ReportedContent/ReportedContent.vue

Import the component on the moderation page component :point_up: 

Refactoring is started in #1954 now.

### Task 2: Write a storybook story

You can find the storybook story here: https://github.com/Human-Connection/Human-Connection/blob/storybook_for_reported_content/webapp/components/ReportedContent/ReportedContent.story.js

It would be great if you could write data to show the `ReportedContent` component if the content is a `Post` a `Comment` or a `User` respectively.

#### Task 2.1: Implement the moderation "log"

As described in the screenshot above :point_up: we didn't really think of a resource being reported multiple times. The desired behaviour now is to group all reports by resource and also show if a moderator has disabled or enabled a resource. This list is called "log" (don't know if that's a good name :thinking:). But I sketched the data in here: https://github.com/Human-Connection/Human-Connection/blob/storybook_for_reported_content/webapp/components/ReportedContent/ReportedContent.story/data.js

So the goal is to list this log just below the row with the reported resource.


### Task 3: Write a component test

You can find a blueprint for a component tere here:
https://github.com/Human-Connection/Human-Connection/blob/storybook_for_reported_content/webapp/components/ReportedContent/ReportedContent.spec.js

In the test you could e.g. test:

* links to the reported content
* given the content is not disabled
  * it shows a dash in the column `Disabled by`
* given the content is disabled
  * it shows who disabled the content

