### PR TITLE
overflow: hidden on body removed when popover

### DIFF
--- a/webapp/assets/styles/main.scss
+++ b/webapp/assets/styles/main.scss
@@ -52,7 +52,6 @@ $easeOut: cubic-bezier(0.19, 1, 0.22, 1);
 
 body.dropdown-open {
   height: 100vh;
-  overflow: hidden;
 }
 
 blockquote {


### PR DESCRIPTION
## 🍰 Pullrequest

The CSS property `overflow: hidden` was set on the `body` when the pointer hover the avatar. I don't know if this was done on purpose, but by removing it, now it doesn't hide the scrollbar.

![Screenshot_20191028_000643](https://user-images.githubusercontent.com/29784958/67643363-eea68d00-f916-11e9-85e9-c031d37b6dfc.png)


### Issues
- fixes #1857

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
