### PR TITLE
Thumbnail in the contribution overview change from 2000px to max-height 357.33px

### DIFF
--- a/webapp/pages/index.vue
+++ b/webapp/pages/index.vue
@@ -220,7 +220,7 @@ export default {
 
 <style lang="scss">
 .ds-card-image img {
-  max-height: 2000px;
+  max-height: 357.33px;
   object-fit: contain;
 }
 


### PR DESCRIPTION
## 🍰 Pullrequest
Thumbnail in the contribuion overview with change from 2000px to max-height 357.33px
in the article itself you can see the picture in full size

![FireShot Capture 177 - Human Connection - Human Connection - localhost](https://user-images.githubusercontent.com/1324583/68289862-35b71f80-0087-11ea-97d0-c0f6c705d0c2.png)


# before it looked like this

![FireShot Capture 178 - Human Connection - Human Connection - localhost](https://user-images.githubusercontent.com/1324583/68289879-3e0f5a80-0087-11ea-9c1f-38c2fd8daaf8.png)


