### PR TITLE
fix(editor): Fix hashtags not working after embeded content

### DIFF
--- a/webapp/components/Editor/defaultExtensions.spec.js
+++ b/webapp/components/Editor/defaultExtensions.spec.js
@@ -63,30 +63,26 @@ describe('defaultExtensions', () => {
     it('recognizes embed code', () => {
       const editor = createEditor()
       const expected = {
+        type: 'doc',
         content: [
           {
+            type: 'paragraph',
             content: [
               {
                 text: 'Baby loves cat:',
-                type: 'text',
-              },
-            ],
-            type: 'paragraph',
+                type: 'text'
+              }
+            ]
           },
           {
-            content: [
-              {
-                attrs: {
-                  dataEmbedUrl: 'https://www.youtube.com/watch?v=qkdXAtO40Fo',
-                },
-                type: 'embed',
-              },
-            ],
-            type: 'paragraph',
-          },
-        ],
-        type: 'doc',
+            type: 'embed',
+            attrs: {
+              dataEmbedUrl: 'https://www.youtube.com/watch?v=qkdXAtO40Fo'
+            }
+          }
+        ]
       }
+
       expect(editor.getJSON()).toEqual(expected)
     })
   })

--- a/webapp/components/Editor/nodes/Embed.js
+++ b/webapp/components/Editor/nodes/Embed.js
@@ -38,8 +38,8 @@ export default class Embed extends Node {
           default: null,
         },
       },
-      group: 'inline',
-      inline: true,
+      group: 'block',
+      inline: false,
       parseDOM: [
         {
           tag: 'a[href].embed',


### PR DESCRIPTION
Up to this point, once you've inserted a given URL to the editor, and it renders a new embeded content, if you hit Return, and try using a tag, or mention, it would not work since the paragraph was never closed.

Unless you explicitly hit return again, to escape the given text block you were in, you could not use mentions. See the PR/Issue for further info.

## 🍰 Pullrequest
This PR fixes this by simply changing the call to the Embeded content, so it is not grouped as "Inline" by the editor, since if this happens, the embeded content will get inserted IN the current block.

### Issues
- fixes #1937 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
