### PR TITLE
fix(editor): Fix embed thumbnail height

### DIFF
--- a/webapp/components/Editor/Editor.vue
+++ b/webapp/components/Editor/Editor.vue
@@ -377,6 +377,7 @@ li > p {
 .embed-preview-image {
   width: 100%;
   height: auto;
+  max-height: 450px;
 }
 
 .embed-preview-image--clickable {


### PR DESCRIPTION
## 🍰 Pullrequest
Simple PR to add max-height for thumbnail images, so we can avoid what happened in the bug report below.

### Issues
- fixes #1936 