### PR TITLE
2187 language does not change on edit

### DIFF
--- a/webapp/assets/styles/main.scss
+++ b/webapp/assets/styles/main.scss
@@ -171,8 +171,6 @@ hr {
 }
 
 .hyphenate-text {
-  -webkit-hyphens: auto;
-  -moz-hyphens: auto;
   hyphens: auto;
   overflow-wrap: break-word;
   word-wrap: break-word;

--- a/webapp/assets/styles/main.scss
+++ b/webapp/assets/styles/main.scss
@@ -171,6 +171,8 @@ hr {
 }
 
 .hyphenate-text {
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
   hyphens: auto;
   overflow-wrap: break-word;
   word-wrap: break-word;

--- a/webapp/components/PostCard/PostCard.vue
+++ b/webapp/components/PostCard/PostCard.vue
@@ -1,6 +1,6 @@
 <template>
   <ds-card
-    :language="language"
+    :lang="language"
     :image="post.image | proxyApiUrl"
     :class="{ 'post-card': true, 'disabled-content': post.disabled, 'post--pinned': isPinned }"
   >

--- a/webapp/components/PostCard/PostCard.vue
+++ b/webapp/components/PostCard/PostCard.vue
@@ -1,5 +1,6 @@
 <template>
   <ds-card
+    :language="language"
     :image="post.image | proxyApiUrl"
     :class="{ 'post-card': true, 'disabled-content': post.disabled, 'post--pinned': isPinned }"
   >
@@ -116,6 +117,10 @@ export default {
         this.post ? this.$filters.truncate(this.post.title, 30) : '',
         this.deletePostCallback,
       )
+    },
+    language() {
+      // if older posts have language not set I assume German as language
+      return this.post.language ? this.post.language : 'de'
     },
     isPinned() {
       return this.post && this.post.pinnedBy

--- a/webapp/components/PostCard/PostCard.vue
+++ b/webapp/components/PostCard/PostCard.vue
@@ -1,6 +1,6 @@
 <template>
   <ds-card
-    :lang="language"
+    :lang="post.language"
     :image="post.image | proxyApiUrl"
     :class="{ 'post-card': true, 'disabled-content': post.disabled, 'post--pinned': isPinned }"
   >
@@ -117,10 +117,6 @@ export default {
         this.post ? this.$filters.truncate(this.post.title, 30) : '',
         this.deletePostCallback,
       )
-    },
-    language() {
-      // if older posts have language not set I assume German as language
-      return this.post.language ? this.post.language : 'de'
     },
     isPinned() {
       return this.post && this.post.pinnedBy

--- a/webapp/graphql/Fragments.js
+++ b/webapp/graphql/Fragments.js
@@ -45,6 +45,7 @@ export const postFragment = lang => gql`
     deleted
     slug
     image
+    language
     author {
       ...user
     }

--- a/webapp/pages/post/_id/_slug/index.vue
+++ b/webapp/pages/post/_id/_slug/index.vue
@@ -1,6 +1,7 @@
 <template>
   <transition name="fade" appear>
     <ds-card
+      :language="language"
       v-if="post && ready"
       :image="post.image | proxyApiUrl"
       :class="{ 'post-card': true, 'disabled-content': post.disabled }"
@@ -146,6 +147,10 @@ export default {
         this.post ? this.$filters.truncate(this.post.title, 30) : '',
         this.deletePostCallback,
       )
+    },
+    language() {
+      // if older posts have language not set I assume German as language
+      return this.post.language ? this.post.language : 'de'
     },
   },
   methods: {

--- a/webapp/pages/post/_id/_slug/index.vue
+++ b/webapp/pages/post/_id/_slug/index.vue
@@ -1,7 +1,7 @@
 <template>
   <transition name="fade" appear>
     <ds-card
-      :lang="language"
+      :lang="post.language"
       v-if="post && ready"
       :image="post.image | proxyApiUrl"
       :class="{ 'post-card': true, 'disabled-content': post.disabled }"
@@ -147,10 +147,6 @@ export default {
         this.post ? this.$filters.truncate(this.post.title, 30) : '',
         this.deletePostCallback,
       )
-    },
-    language() {
-      // if older posts have language not set I assume German as language
-      return this.post.language ? this.post.language : 'de'
     },
   },
   methods: {

--- a/webapp/pages/post/_id/_slug/index.vue
+++ b/webapp/pages/post/_id/_slug/index.vue
@@ -1,7 +1,7 @@
 <template>
   <transition name="fade" appear>
     <ds-card
-      :language="language"
+      :lang="language"
       v-if="post && ready"
       :image="post.image | proxyApiUrl"
       :class="{ 'post-card': true, 'disabled-content': post.disabled }"


### PR DESCRIPTION
## 🍰 Pullrequest
Language property of post is passed to frontend. When editing post in a different locale the language does not change by default. Added language attributes to post and postcard (article element in html) to have the hyphenation corresponding to the language of the post and not to the chosen locale.

### Issues
- fixes #2187
- fixes #2115 


### ToDo
- [ ] Admins should run a batch job to assign `de` as language to all posts where language is null
