### PR TITLE
build(deps): remove deprecated debug flags

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -6,6 +6,7 @@
 * [Neo4J](neo4j/README.md)
 * [Backend](backend/README.md)
   * [GraphQL](backend/graphql.md)
+  * [neo4j-graphql-js](backend/neo4j-graphql-js.md)
 * [Webapp](webapp/README.md)
   * [Components](webapp/components.md)
   * [HTML](webapp/html.md)

--- a/backend/neo4j-graphql-js.md
+++ b/backend/neo4j-graphql-js.md
@@ -1,0 +1,16 @@
+# neo4j-graphql.js
+
+We use an npm package called `neo4j-graphql-js` as a cypher query builder. This
+library also generates resolvers for graphql queries, unless we implement it
+ourselves.
+
+
+## Debugging
+
+As you can see in their [documentation](https://github.com/neo4j-graphql/neo4j-graphql-js)
+it is possible to log out the generated cypher statements. To do so, run the
+backend like this:
+
+```sh
+DEBUG=neo4j-graphql-js yarn run dev
+```

--- a/backend/neo4j-graphql-js.md
+++ b/backend/neo4j-graphql-js.md
@@ -1,7 +1,7 @@
 # neo4j-graphql.js
 
 We use an npm package called `neo4j-graphql-js` as a cypher query builder. This
-library also generates resolvers for graphql queries, unless we implement it
+library also generates resolvers for graphql queries, unless we implement them
 ourselves.
 
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
     "build": "babel src/ -d dist/ --copy-files",
     "start": "node dist/",
     "dev": "nodemon --exec babel-node src/ -e js,gql",
+    "debug": "DEBUG=neo4j-graphql-js yarn dev",
     "dev:debug": "nodemon --exec babel-node --inspect=0.0.0.0:9229 src/index.js -e js,gql",
     "lint": "eslint src --config .eslintrc.js",
     "test": "jest --forceExit --detectOpenHandles --runInBand",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,6 @@
     "build": "babel src/ -d dist/ --copy-files",
     "start": "node dist/",
     "dev": "nodemon --exec babel-node src/ -e js,gql",
-    "debug": "DEBUG=neo4j-graphql-js yarn dev",
     "dev:debug": "nodemon --exec babel-node --inspect=0.0.0.0:9229 src/index.js -e js,gql",
     "lint": "eslint src --config .eslintrc.js",
     "test": "jest --forceExit --detectOpenHandles --runInBand",

--- a/backend/package.json
+++ b/backend/package.json
@@ -83,7 +83,7 @@
     "minimatch": "^3.0.4",
     "mustache": "^3.1.0",
     "neo4j-driver": "~1.7.6",
-    "neo4j-graphql-js": "^2.8.0",
+    "neo4j-graphql-js": "^2.9.0",
     "neode": "^0.3.3",
     "node-fetch": "~2.6.0",
     "nodemailer": "^6.3.1",

--- a/backend/src/schema/resolvers/badges.js
+++ b/backend/src/schema/resolvers/badges.js
@@ -3,7 +3,7 @@ import { neo4jgraphql } from 'neo4j-graphql-js'
 export default {
   Query: {
     Badge: async (object, args, context, resolveInfo) => {
-      return neo4jgraphql(object, args, context, resolveInfo, false)
+      return neo4jgraphql(object, args, context, resolveInfo)
     },
   },
 }

--- a/backend/src/schema/resolvers/posts.js
+++ b/backend/src/schema/resolvers/posts.js
@@ -43,15 +43,15 @@ export default {
     Post: async (object, params, context, resolveInfo) => {
       params = await filterForBlockedUsers(params, context)
       params = await maintainPinnedPosts(params)
-      return neo4jgraphql(object, params, context, resolveInfo, false)
+      return neo4jgraphql(object, params, context, resolveInfo)
     },
     findPosts: async (object, params, context, resolveInfo) => {
       params = await filterForBlockedUsers(params, context)
-      return neo4jgraphql(object, params, context, resolveInfo, false)
+      return neo4jgraphql(object, params, context, resolveInfo)
     },
     profilePagePosts: async (object, params, context, resolveInfo) => {
       params = await filterForBlockedUsers(params, context)
-      return neo4jgraphql(object, params, context, resolveInfo, false)
+      return neo4jgraphql(object, params, context, resolveInfo)
     },
     PostsEmotionsCountByEmotion: async (object, params, context, resolveInfo) => {
       const session = context.driver.session()

--- a/backend/src/schema/resolvers/users.js
+++ b/backend/src/schema/resolvers/users.js
@@ -54,7 +54,7 @@ export default {
         user = await user.toJson()
         return [user.node]
       }
-      return neo4jgraphql(object, args, context, resolveInfo, false)
+      return neo4jgraphql(object, args, context, resolveInfo)
     },
   },
   Mutation: {

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -6070,10 +6070,10 @@ neo4j-driver@^1.7.3, neo4j-driver@^1.7.5, neo4j-driver@~1.7.6:
     text-encoding-utf-8 "^1.0.2"
     uri-js "^4.2.2"
 
-neo4j-graphql-js@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/neo4j-graphql-js/-/neo4j-graphql-js-2.8.0.tgz#58035b9213656e17b6ed4c6cbf4dfe1c56a8a219"
-  integrity sha512-nDuzmi6W/YGIIVm+GAXCr/8CLABsU/RfeLebLH32vqeKViFATMfm4eT66aOq/GwHJ0838+o20yCbIFdx5rTP/A==
+neo4j-graphql-js@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/neo4j-graphql-js/-/neo4j-graphql-js-2.9.0.tgz#b214a0546479565cb5b812fb7e602f2136d36a0d"
+  integrity sha512-vpOUPwx7Xwn2EZoe0i9z+AMJ4uwZeUjWDGiR4ZAR6ebNd5BaYpiC9SihYOZlS3hVXHZxADQfpGhz9dx++lZwlg==
   dependencies:
     "@babel/runtime" "^7.5.5"
     "@babel/runtime-corejs2" "^7.5.5"


### PR DESCRIPTION
I deprecated the debug flags myself here:
https://github.com/neo4j-graphql/neo4j-graphql-js/pull/288

You can now debug the queries run by `neo4j-graphql-js` by starting
the backend like this:

```bash
DEBUG=neo4j-graphql-js yarn run backend
```

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
