### PR TITLE
fix(editor): Fix hashtags not working after embeded content

### DIFF
--- a/webapp/components/Editor/defaultExtensions.spec.js
+++ b/webapp/components/Editor/defaultExtensions.spec.js
@@ -70,17 +70,17 @@ describe('defaultExtensions', () => {
             content: [
               {
                 text: 'Baby loves cat:',
-                type: 'text'
-              }
-            ]
+                type: 'text',
+              },
+            ],
           },
           {
             type: 'embed',
             attrs: {
-              dataEmbedUrl: 'https://www.youtube.com/watch?v=qkdXAtO40Fo'
-            }
-          }
-        ]
+              dataEmbedUrl: 'https://www.youtube.com/watch?v=qkdXAtO40Fo',
+            },
+          },
+        ],
       }
 
       expect(editor.getJSON()).toEqual(expected)


### PR DESCRIPTION
Up to this point, once you've inserted a given URL to the editor, and it renders a new embeded content, if you hit Return, and try using a tag, or mention, it would not work since the paragraph was never closed.

Unless you explicitly hit return again, to escape the given text block you were in, you could not use mentions. See the PR/Issue for further info.

## 🍰 Pullrequest
This PR fixes this by simply changing the call to the Embeded content, so it is not grouped as "Inline" by the editor, since if this happens, the embeded content will get inserted IN the current block.

### Issues
- fixes #1937 
- fixes the required changes on #2152