### PR TITLE
build: less verbose output on build server

### DIFF
--- a/docker-compose.build-and-test.yml
+++ b/docker-compose.build-and-test.yml
@@ -2,11 +2,15 @@ version: "3.4"
 
 services:
   webapp:
+    environment:
+      - "CI=${CI}"
     image: humanconnection/nitro-web:build-and-test
     build:
       context: webapp
       target: build-and-test
   backend:
+    environment:
+      - "CI=${CI}"
     image: humanconnection/nitro-backend:build-and-test
     build:
       context: backend


### PR DESCRIPTION
I'm annoyed to scroll when I'm debugging the build server logs. I think,
if you run `jest` with an environment variable `CI` set to true, it will
not try to output colorized log and also does not output which test it's
currently running.

That should lead to the desired, smaller log on Travis CI.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
