### PR TITLE
If an admin searches for a user by email, don't crash if no user can be found

### DIFF
--- a/backend/src/middleware/permissionsMiddleware.js
+++ b/backend/src/middleware/permissionsMiddleware.js
@@ -100,7 +100,7 @@ const noEmailFilter = rule({
 const publicRegistration = rule()(() => !!CONFIG.PUBLIC_REGISTRATION)
 
 // Permissions
-const permissions = shield(
+export default shield(
   {
     Query: {
       '*': deny,
@@ -176,5 +176,3 @@ const permissions = shield(
     fallbackRule: allow,
   },
 )
-
-export default permissions

--- a/backend/src/schema/resolvers/users.spec.js
+++ b/backend/src/schema/resolvers/users.spec.js
@@ -70,6 +70,21 @@ describe('User', () => {
           data: { User: [{ name: 'Johnny' }] },
         })
       })
+
+      it('non-existing email address, issue #2294', async () => {
+        // see: https://github.com/Human-Connection/Human-Connection/issues/2294
+        await expect(
+          query({
+            query: userQuery,
+            variables: {
+              email: 'this-email-does-not-exist@example.org',
+            },
+          }),
+        ).resolves.toMatchObject({
+          data: { User: [] },
+          errors: undefined,
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
Ideally we would not have this inconsistent edge case that we filter
through the user type. Much better would be a graphql query like:

```graphql
{
  User(filter: { primary_email: { email: "something@example.org" } }) {
    id
    name
    slug
  }
}
```

**EDIT**
I tried to implement the above behaviour and I think it's OK to have this edge case. Reason: you could nest `_UserFilter` indefinitely. So it becomes complex and risky to create a `graphql-shield` rule based on `args.filter.primary_email`.

Keeping it simple stupid and having this one inconsistency is OK I would say.

Fix #2294 