### PR TITLE
2329 normalize emails in login form

### DIFF
--- a/backend/src/schema/resolvers/user_management.js
+++ b/backend/src/schema/resolvers/user_management.js
@@ -2,6 +2,7 @@ import encode from '../../jwt/encode'
 import bcrypt from 'bcryptjs'
 import { AuthenticationError } from 'apollo-server'
 import { neode } from '../../bootstrap/neo4j'
+import { normalizeEmail } from 'validator'
 
 const instance = neode()
 
@@ -21,6 +22,7 @@ export default {
       // if (user && user.id) {
       //   throw new Error('Already logged in.')
       // }
+      email = normalizeEmail(email)
       const session = driver.session()
       const result = await session.run(
         `

--- a/webapp/components/LoginForm/LoginForm.spec.js
+++ b/webapp/components/LoginForm/LoginForm.spec.js
@@ -57,17 +57,6 @@ describe('LoginForm', () => {
           undefined,
         )
       })
-
-      describe('given email is a gmail address', () => {
-        it('removes dots, issue #2329', () => {
-          fillIn(Wrapper(), { email: 'example.user@gmail.com' })
-          expect(storeMocks.actions['auth/login']).toHaveBeenCalledWith(
-            expect.any(Object),
-            { email: 'exampleuser@gmail.com', password: '1234' },
-            undefined,
-          )
-        })
-      })
     })
   })
 })

--- a/webapp/components/LoginForm/LoginForm.spec.js
+++ b/webapp/components/LoginForm/LoginForm.spec.js
@@ -1,0 +1,73 @@
+import LoginForm from './LoginForm.vue'
+import Styleguide from '@human-connection/styleguide'
+import Vuex from 'vuex'
+import { config, mount, createLocalVue } from '@vue/test-utils'
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+localVue.use(Styleguide)
+
+config.stubs['nuxt-link'] = '<span><slot /></span>'
+config.stubs['locale-switch'] = '<span><slot /></span>'
+config.stubs['client-only'] = '<span><slot /></span>'
+
+describe('LoginForm', () => {
+  let mocks
+  let propsData
+  let storeMocks
+
+  beforeEach(() => {
+    propsData = {}
+  })
+
+  describe('mount', () => {
+    const Wrapper = () => {
+      storeMocks = {
+        getters: {
+          'auth/pending': () => false,
+        },
+        actions: {
+          'auth/login': jest.fn(),
+        },
+      }
+      const store = new Vuex.Store(storeMocks)
+      mocks = {
+        $t: () => {},
+        $toast: {
+          success: jest.fn(),
+          error: jest.fn(),
+        },
+      }
+      return mount(LoginForm, { mocks, localVue, propsData, store })
+    }
+
+    describe('fill in email and password and submit', () => {
+      const fillIn = (wrapper, opts = {}) => {
+        const { email = 'email@example.org', password = '1234' } = opts
+        wrapper.find('input[name="email"]').setValue(email)
+        wrapper.find('input[name="password"]').setValue(password)
+        wrapper.find('form').trigger('submit')
+      }
+
+      it('dispatches login with form data', () => {
+        fillIn(Wrapper())
+        expect(storeMocks.actions['auth/login']).toHaveBeenCalledWith(
+          expect.any(Object),
+          { email: 'email@example.org', password: '1234' },
+          undefined,
+        )
+      })
+
+      describe('given email is a gmail address', () => {
+        it('removes dots, issue #2329', () => {
+          fillIn(Wrapper(), { email: 'example.user@gmail.com' })
+          expect(storeMocks.actions['auth/login']).toHaveBeenCalledWith(
+            expect.any(Object),
+            { email: 'exampleuser@gmail.com', password: '1234' },
+            undefined,
+          )
+        })
+      })
+    })
+  })
+})

--- a/webapp/components/LoginForm/LoginForm.vue
+++ b/webapp/components/LoginForm/LoginForm.vue
@@ -73,6 +73,7 @@
 
 <script>
 import LocaleSwitch from '~/components/LocaleSwitch/LocaleSwitch.vue'
+import { normalizeEmail } from 'validator'
 
 export default {
   components: {
@@ -93,8 +94,10 @@ export default {
   },
   methods: {
     async onSubmit() {
+      let { email, password } = this.form
+      email = normalizeEmail(email)
       try {
-        await this.$store.dispatch('auth/login', { ...this.form })
+        await this.$store.dispatch('auth/login', { email, password })
         this.$toast.success(this.$t('login.success'))
         this.$emit('success')
       } catch (err) {

--- a/webapp/components/LoginForm/LoginForm.vue
+++ b/webapp/components/LoginForm/LoginForm.vue
@@ -73,7 +73,6 @@
 
 <script>
 import LocaleSwitch from '~/components/LocaleSwitch/LocaleSwitch.vue'
-import { normalizeEmail } from 'validator'
 
 export default {
   components: {
@@ -94,8 +93,7 @@ export default {
   },
   methods: {
     async onSubmit() {
-      let { email, password } = this.form
-      email = normalizeEmail(email)
+      const { email, password } = this.form
       try {
         await this.$store.dispatch('auth/login', { email, password })
         this.$toast.success(this.$t('login.success'))


### PR DESCRIPTION
## 🍰 Pullrequest

I first created a frontend spec before I learned that I can (and should) normalize the email in the backend in the `login` resolver.

### Issues
- fix #2329 

