### PR TITLE
Update test description

### DIFF
--- a/backend/src/middleware/notifications/notificationsMiddleware.spec.js
+++ b/backend/src/middleware/notifications/notificationsMiddleware.spec.js
@@ -371,7 +371,7 @@ describe('notifications', () => {
                 expect(readAfter).toEqual(false)
               })
 
-              it('updates the `createdAt` attribute', async () => {
+              it('does not update the `createdAt` attribute', async () => {
                 await createPostAction()
                 await markAsReadAction()
                 const {


### PR DESCRIPTION
- the test clearly tests that the createdAt doesn't change, we changed
the implementation, but didn't change the test description
