### PR TITLE
Use babel-loader with vue-svg-loader

### DIFF
--- a/webapp/nuxt.config.js
+++ b/webapp/nuxt.config.js
@@ -258,19 +258,24 @@ export default {
       svgRule.test = /\.(png|jpe?g|gif|webp)$/
       config.module.rules.push({
         test: /\.svg$/,
-        loader: 'vue-svg-loader',
-        options: {
-          svgo: {
-            plugins: [
-              {
-                removeViewBox: false,
+        use: [
+          'babel-loader',
+          {
+            loader: 'vue-svg-loader',
+            options: {
+              svgo: {
+                plugins: [
+                  {
+                    removeViewBox: false,
+                  },
+                  {
+                    removeDimensions: true,
+                  },
+                ],
               },
-              {
-                removeDimensions: true,
-              },
-            ],
+            },
           },
-        },
+        ],
       })
     },
   },

--- a/webapp/storybook/webpack.config.js
+++ b/webapp/storybook/webpack.config.js
@@ -41,19 +41,24 @@ module.exports = async ({ config, mode }) => {
 
   config.module.rules.push({
     test: /\.svg$/,
-    loader: 'vue-svg-loader',
-    options: {
-      svgo: {
-        plugins: [
-          {
-            removeViewBox: false,
+    use: [
+      'babel-loader',
+      {
+        loader: 'vue-svg-loader',
+        options: {
+          svgo: {
+            plugins: [
+              {
+                removeViewBox: false,
+              },
+              {
+                removeDimensions: true,
+              },
+            ],
           },
-          {
-            removeDimensions: true,
-          },
-        ],
+        },
       },
-    },
+    ],
   })
 
   config.resolve.alias = {


### PR DESCRIPTION
## 🍰 Pullrequest
(Some of?) our browser issues in Edge and IE are caused by object spread operators, being left in the minified code after transpiling `svgs`. I could only confirm this for the `styleguide` but since using `babel-loader` alongside `vue-svg-loader` is recommended in the [official docs](https://vue-svg-loader.js.org/#configuration) it sure can't hurt.

### Issues
- relates (and maybe solves) #2287 

### Todo
- [ ] merge the [related PR](https://github.com/Human-Connection/Nitro-Styleguide/pull/190), then release and upgrade the styleguide
