### PR TITLE
Eliminate database calls for reports query

### DIFF
--- a/backend/src/schema/resolvers/reports.js
+++ b/backend/src/schema/resolvers/reports.js
@@ -144,7 +144,6 @@ export default {
       })
       try {
         const txResult = await readTxPromise
-        if (!txResult[0]) return null
         reviewed = txResult.map(reportedRecord => {
           const { review, moderator } = reportedRecord
           const relationshipWithNestedAttributes = {

--- a/backend/src/schema/resolvers/reports.js
+++ b/backend/src/schema/resolvers/reports.js
@@ -66,14 +66,17 @@ export default {
       const reportReadTxPromise = session.readTransaction(async tx => {
         const allReportsTransactionResponse = await tx.run(
           `
-          MATCH (submitter:User)-[filed:FILED]->(report:Report)-[:BELONGS_TO]->(resource)
+          MATCH (report:Report)-[:BELONGS_TO]->(resource)
           WHERE resource:User OR resource:Post OR resource:Comment
-          RETURN DISTINCT report, resource, labels(resource)[0] as type
+          WITH report, resource,
+          [(submitter:User)-[filed:FILED]->(report) |  filed {.*, submitter: properties(submitter)} ] as filed,
+          [(moderator:User)-[reviewed:REVIEWED]->(report) |  reviewed {.*, moderator: properties(moderator)} ] as reviewed,
+          resource {.*, __typename: labels(resource)[0] } as resourceWithType
+          RETURN report {.*, resource: resourceWithType, filed: filed, reviewed: reviewed}
           ${orderByClause}
           `,
-          {},
         )
-        return allReportsTransactionResponse.records.map(transformReturnType)
+        return allReportsTransactionResponse.records.map(record => record.get('report'))
       })
       try {
         const txResult = await reportReadTxPromise

--- a/webapp/components/features/ReportList/ReportList.story.js
+++ b/webapp/components/features/ReportList/ReportList.story.js
@@ -101,7 +101,7 @@ export const reports = [
       slug: 'bigoted-post',
       title: "I'm a bigoted post!",
     },
-    reviewed: null,
+    reviewed: [],
   },
   {
     __typename: 'Report',

--- a/webapp/components/features/ReportRow/ReportRow.vue
+++ b/webapp/components/features/ReportRow/ReportRow.vue
@@ -40,7 +40,7 @@
           <base-icon :name="statusIconName" :class="isDisabled ? '--disabled' : '--enabled'" />
           {{ statusText }}
         </span>
-        <client-only v-if="report.reviewed">
+        <client-only v-if="isReviewed">
           <hc-user
             :user="moderatorOfLatestReview"
             :showAvatar="false"
@@ -109,6 +109,10 @@ export default {
     isDisabled() {
       return this.report.resource.disabled
     },
+    isReviewed() {
+      const { reviewed } = this.report
+      return reviewed && reviewed.length
+    },
     iconName() {
       if (this.isPost) return 'bookmark'
       else if (this.isComment) return 'comments'
@@ -138,12 +142,13 @@ export default {
       return this.isDisabled ? 'eye-slash' : 'eye'
     },
     statusText() {
-      if (!this.report.reviewed) return this.$t('moderation.reports.enabled')
+      if (!this.isReviewed) return this.$t('moderation.reports.enabled')
       else if (this.isDisabled) return this.$t('moderation.reports.disabledBy')
       else return this.$t('moderation.reports.enabledBy')
     },
     moderatorOfLatestReview() {
-      return this.report.reviewed[0].moderator
+      const [latestReview] = this.report.reviewed
+      return latestReview && latestReview.moderator
     },
   },
 }


### PR DESCRIPTION
## 🍰 Pullrequest
    Return empty array instead null for "not reviewed"

    @mattwr18 why did you add the null check in th resolver?

---------
    Eliminate database calls for filed and reviewed

    I learned map projections and list comprehensions in cypher tonight!
    :tada: So much wow!

### Issues
This eliminates **2n** database calls for n the number of all reports.

We could bring this to a next level by optionally matching the author (in case of a post or comment) and the post (in case of a comment), both adding another n database calls to the resolver.

**Before**
![2019-12-06-022419_1920x1080_scrot](https://user-images.githubusercontent.com/2110676/70288791-0ead5400-17d3-11ea-92f3-1989b05d6ba5.png)


**After**
![2019-12-06-022140_1920x1080_scrot](https://user-images.githubusercontent.com/2110676/70288810-1ff66080-17d3-11ea-8e6e-7a82ea392d1f.png)


