### PR TITLE
Hope to fix our deployment with explicit call of `bash`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,14 +63,14 @@ before_deploy:
 
 deploy:
   - provider: script
-    script: scripts/docker_push.sh
+    script: bash scripts/docker_push.sh
     on:
       branch: master
   - provider: script
-    script: scripts/deploy.sh
+    script: bash scripts/deploy.sh
     on:
       branch: master
   - provider: script
-    script: scripts/github_release.sh
+    script: bash scripts/github_release.sh
     on:
       branch: master

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -5,7 +5,7 @@ DOCKER_CLI_EXPERIMENTAL=enabled
 
 IFS='.' read -r major minor patch < $ROOT_DIR/VERSION
 apps=(nitro-web nitro-backend neo4j maintenance)
-tags=(latest $major $major.$minor $major.$minor.$patch)
+tags=($major $major.$minor $major.$minor.$patch)
 
 # These three docker images have already been built by now:
 # docker build --build-arg BUILD_COMMIT=$BUILD_COMMIT --target production -t humanconnection/nitro-backend:latest $ROOT_DIR/backend
@@ -17,13 +17,17 @@ echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
 for app in "${apps[@]}"
 do
+  SOURCE="humanconnection/${app}:latest"
+  echo "docker push $SOURCE"
+  docker push $SOURCE
+
   for tag in "${tags[@]}"
   do
-    SOURCE="humanconnection/${app}:latest"
     TARGET="humanconnection/${app}:${tag}"
-    if docker manifest inspect $TARGET &> /dev/null; then
-      echo "Docker image ${TARGET} already present, skipping ..."
+    if docker manifest inspect $TARGET >/dev/null; then
+      echo "docker image ${TARGET} already present, skipping ..."
     else
+      echo -e "docker tag $SOURCE $TARGET\ndocker push $TARGET"
       docker tag $SOURCE $TARGET
       docker push $TARGET
     fi


### PR DESCRIPTION
We should have been wary after seeing the version tags in the same loop as the
`latest` tag.

## 🍰 Pullrequest
This should fix our deployment in such a way that version tags are only pushed when they change and when there is no docker image already online (it should not override it).