### PR TITLE
Show the comments again

### DIFF
--- a/webapp/components/PostCard/PostCard.vue
+++ b/webapp/components/PostCard/PostCard.vue
@@ -144,7 +144,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 .ds-card-image img {
   width: 100%;
   max-height: 2000px;


### PR DESCRIPTION
@alina-beck the CSS class `.ds-card-footer` gets in the way of the
`overflow: hidden` from the styleguide. The scoping avoids the issue.

Of course this is not a great solution and the whole file needs to be
refactored and fixed. I also see a lot of `<div>`s with a style
attribute. All of that is legacy code that survived for too long.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
