### PR TITLE
Fix duplicate fragment `user` issue

### DIFF
--- a/webapp/graphql/Fragments.js
+++ b/webapp/graphql/Fragments.js
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag'
 
-export const linkableUserFragment = lang => gql`
+export const userFragment = gql`
   fragment user on User {
     id
     slug
@@ -10,19 +10,8 @@ export const linkableUserFragment = lang => gql`
     deleted
   }
 `
-export const userFragment = lang => gql`
-  fragment user on User {
-    id
-    slug
-    name
-    avatar
-    disabled
-    deleted
-    shoutedCount
-    contributionsCount
-    commentedCount
-    followedByCount
-    followedByCurrentUser
+export const locationAndBadgesFragment = lang => gql`
+  fragment locationAndBadges on User {
     location {
       name: name${lang}
     }
@@ -33,15 +22,17 @@ export const userFragment = lang => gql`
   }
 `
 
-export const postCountsFragment = gql`
-  fragment postCounts on Post {
-    commentsCount
+export const userCountsFragment = gql`
+  fragment userCounts on User {
     shoutedCount
-    shoutedByCurrentUser
-    emotionsCount
+    contributionsCount
+    commentedCount
+    followedByCount
+    followedByCurrentUser
   }
 `
-export const postFragment = lang => gql`
+
+export const postFragment = gql`
   fragment post on Post {
     id
     title
@@ -54,9 +45,22 @@ export const postFragment = lang => gql`
     slug
     image
     language
-    author {
-      ...user
-    }
+    pinnedAt
+    imageAspectRatio
+  }
+`
+
+export const postCountsFragment = gql`
+  fragment postCounts on Post {
+    commentsCount
+    shoutedCount
+    shoutedByCurrentUser
+    emotionsCount
+  }
+`
+
+export const tagsCategoriesAndPinnedFragment = gql`
+  fragment tagsCategoriesAndPinned on Post {
     tags {
       id
     }
@@ -71,11 +75,10 @@ export const postFragment = lang => gql`
       name
       role
     }
-    pinnedAt
-    imageAspectRatio
   }
 `
-export const commentFragment = lang => gql`
+
+export const commentFragment = gql`
   fragment comment on Comment {
     id
     createdAt
@@ -84,8 +87,5 @@ export const commentFragment = lang => gql`
     deleted
     content
     contentExcerpt
-    author {
-      ...user
-    }
   }
 `

--- a/webapp/graphql/PostQuery.js
+++ b/webapp/graphql/PostQuery.js
@@ -1,20 +1,42 @@
 import gql from 'graphql-tag'
-import { userFragment, postFragment, commentFragment, postCountsFragment } from './Fragments'
+import {
+  userFragment,
+  postFragment,
+  commentFragment,
+  postCountsFragment,
+  userCountsFragment,
+  locationAndBadgesFragment,
+  tagsCategoriesAndPinnedFragment,
+} from './Fragments'
 
 export default i18n => {
   const lang = i18n.locale().toUpperCase()
   return gql`
-    ${userFragment(lang)}
-    ${postFragment(lang)}
+    ${userFragment}
+    ${userCountsFragment}
+    ${locationAndBadgesFragment(lang)}
+    ${postFragment}
     ${postCountsFragment}
-    ${commentFragment(lang)}
+    ${tagsCategoriesAndPinnedFragment}
+    ${commentFragment}
 
     query Post($id: ID!) {
       Post(id: $id) {
         ...post
         ...postCounts
+        ...tagsCategoriesAndPinned
+        author {
+          ...user
+          ...userCounts
+          ...locationAndBadges
+        }
         comments(orderBy: createdAt_asc) {
           ...comment
+          author {
+            ...user
+            ...userCounts
+            ...locationAndBadges
+          }
         }
       }
     }
@@ -24,14 +46,23 @@ export default i18n => {
 export const filterPosts = i18n => {
   const lang = i18n.locale().toUpperCase()
   return gql`
-    ${userFragment(lang)}
-    ${postFragment(lang)}
+    ${userFragment}
+    ${userCountsFragment}
+    ${locationAndBadgesFragment(lang)}
+    ${postFragment}
     ${postCountsFragment}
+    ${tagsCategoriesAndPinnedFragment}
 
     query Post($filter: _PostFilter, $first: Int, $offset: Int, $orderBy: [_PostOrdering]) {
       Post(filter: $filter, first: $first, offset: $offset, orderBy: $orderBy) {
         ...post
         ...postCounts
+        ...tagsCategoriesAndPinned
+        author {
+          ...user
+          ...userCounts
+          ...locationAndBadges
+        }
       }
     }
   `
@@ -40,9 +71,12 @@ export const filterPosts = i18n => {
 export const profilePagePosts = i18n => {
   const lang = i18n.locale().toUpperCase()
   return gql`
-    ${userFragment(lang)}
-    ${postFragment(lang)}
+    ${userFragment}
+    ${userCountsFragment}
+    ${locationAndBadgesFragment(lang)}
+    ${postFragment}
     ${postCountsFragment}
+    ${tagsCategoriesAndPinnedFragment}
 
     query profilePagePosts(
       $filter: _PostFilter
@@ -53,6 +87,12 @@ export const profilePagePosts = i18n => {
       profilePagePosts(filter: $filter, first: $first, offset: $offset, orderBy: $orderBy) {
         ...post
         ...postCounts
+        ...tagsCategoriesAndPinned
+        author {
+          ...user
+          ...userCounts
+          ...locationAndBadges
+        }
       }
     }
   `
@@ -69,17 +109,32 @@ export const PostsEmotionsByCurrentUser = () => {
 export const relatedContributions = i18n => {
   const lang = i18n.locale().toUpperCase()
   return gql`
-    ${userFragment(lang)}
-    ${postFragment(lang)}
+    ${userFragment}
+    ${userCountsFragment}
+    ${locationAndBadgesFragment(lang)}
+    ${postFragment}
     ${postCountsFragment}
+    ${tagsCategoriesAndPinnedFragment}
 
     query Post($slug: String!) {
       Post(slug: $slug) {
         ...post
         ...postCounts
+        ...tagsCategoriesAndPinned
+        author {
+          ...user
+          ...userCounts
+          ...locationAndBadges
+        }
         relatedContributions(first: 2) {
           ...post
           ...postCounts
+          ...tagsCategoriesAndPinned
+          author {
+            ...user
+            ...userCounts
+            ...locationAndBadges
+          }
         }
       }
     }

--- a/webapp/graphql/User.js
+++ b/webapp/graphql/User.js
@@ -1,27 +1,38 @@
 import gql from 'graphql-tag'
-import { linkableUserFragment, userFragment, postFragment, commentFragment } from './Fragments'
+import {
+  userCountsFragment,
+  locationAndBadgesFragment,
+  userFragment,
+  postFragment,
+  commentFragment,
+} from './Fragments'
 
 export default i18n => {
   const lang = i18n.locale().toUpperCase()
   return gql`
-    ${userFragment(lang)}
+    ${userFragment}
+    ${userCountsFragment}
+    ${locationAndBadgesFragment(lang)}
 
     query User($id: ID!) {
       User(id: $id) {
         ...user
+        ...userCounts
+        ...locationAndBadges
         about
         locationName
         createdAt
-        badgesCount
-        followingCount
-        following(first: 7) {
-          ...user
-        }
-        followedByCount
         followedByCurrentUser
         isBlocked
+        following(first: 7) {
+          ...user
+          ...userCounts
+          ...locationAndBadges
+        }
         followedBy(first: 7) {
           ...user
+          ...userCounts
+          ...locationAndBadges
         }
         socialMedia {
           id
@@ -47,11 +58,10 @@ export const minimisedUserQuery = () => {
 }
 
 export const notificationQuery = i18n => {
-  const lang = i18n.locale().toUpperCase()
   return gql`
-    ${linkableUserFragment()}
-    ${commentFragment(lang)}
-    ${postFragment(lang)}
+    ${userFragment}
+    ${commentFragment}
+    ${postFragment}
 
     query($read: Boolean, $orderBy: NotificationOrdering, $first: Int, $offset: Int) {
       notifications(read: $read, orderBy: $orderBy, first: $first, offset: $offset) {
@@ -63,11 +73,20 @@ export const notificationQuery = i18n => {
           __typename
           ... on Post {
             ...post
+            author {
+              ...user
+            }
           }
           ... on Comment {
             ...comment
+            author {
+              ...user
+            }
             post {
               ...post
+              author {
+                ...user
+              }
             }
           }
         }
@@ -77,11 +96,10 @@ export const notificationQuery = i18n => {
 }
 
 export const markAsReadMutation = i18n => {
-  const lang = i18n.locale().toUpperCase()
   return gql`
-    ${linkableUserFragment()}
-    ${commentFragment(lang)}
-    ${postFragment(lang)}
+    ${userFragment}
+    ${commentFragment}
+    ${postFragment}
 
     mutation($id: ID!) {
       markAsRead(id: $id) {
@@ -93,11 +111,17 @@ export const markAsReadMutation = i18n => {
           __typename
           ... on Post {
             ...post
+            author {
+              ...user
+            }
           }
           ... on Comment {
             ...comment
             post {
               ...post
+              author {
+                ...user
+              }
             }
           }
         }
@@ -107,16 +131,19 @@ export const markAsReadMutation = i18n => {
 }
 
 export const followUserMutation = i18n => {
-  const lang = i18n.locale().toUpperCase()
   return gql`
-    ${userFragment(lang)}
+    ${userFragment}
+    ${userCountsFragment}
+
     mutation($id: ID!) {
       followUser(id: $id) {
-        name
+        ...user
+        ...userCounts
         followedByCount
         followedByCurrentUser
         followedBy(first: 7) {
           ...user
+          ...userCounts
         }
       }
     }
@@ -124,16 +151,19 @@ export const followUserMutation = i18n => {
 }
 
 export const unfollowUserMutation = i18n => {
-  const lang = i18n.locale().toUpperCase()
   return gql`
-    ${userFragment(lang)}
+    ${userFragment}
+    ${userCountsFragment}
+
     mutation($id: ID!) {
       unfollowUser(id: $id) {
-        name
+        ...user
+        ...userCounts
         followedByCount
         followedByCurrentUser
         followedBy(first: 7) {
           ...user
+          ...userCounts
         }
       }
     }


### PR DESCRIPTION
This is refactoring all our fragments and fixing the warning about an
existing name `user`. Apparently, fragments should have a unique name
globally.

I decided to call `userFragment`, `postFragment` the fragments for one
object and use different names to query for related objects.

I would be glad to learn a better way to handle this.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
