### PR TITLE
Fix imageAspectRatio set to null UpdatePost

### DIFF
--- a/webapp/components/ContributionForm/ContributionForm.spec.js
+++ b/webapp/components/ContributionForm/ContributionForm.spec.js
@@ -308,6 +308,7 @@ describe('ContributionForm.vue', () => {
                 name: 'Democracy & Politics',
               },
             ],
+            imageAspectRatio: 1,
           },
         }
         wrapper = Wrapper()
@@ -354,7 +355,7 @@ describe('ContributionForm.vue', () => {
               categoryIds: ['cat12'],
               image,
               imageUpload: null,
-              imageAspectRatio: null,
+              imageAspectRatio: 1,
             },
           }
         })

--- a/webapp/components/ContributionForm/ContributionForm.vue
+++ b/webapp/components/ContributionForm/ContributionForm.vue
@@ -169,6 +169,7 @@ export default {
           ? languageOptions.find(o => this.contribution.language === o.value)
           : null
       form.categoryIds = this.categoryIds(this.contribution.categories)
+      form.imageAspectRatio = this.contribution.imageAspectRatio
       form.blurImage = this.contribution.imageBlurred
     }
 


### PR DESCRIPTION
- we were not setting the form.imageAspectRatio to the value of the
post's imageAspectRatio, so when a user updated their post, but did not
update their imageAspectRatio it would set it to null

@alina-beck 