### PR TITLE
fix: cypress breaks locally in login step

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -60,7 +60,6 @@ Cypress.Commands.add("login", ({ email, password }) => {
     .as("submitButton")
     .click();
   cy.get(".iziToast-message").should("contain", "You are logged in!");
-  cy.get(".iziToast-close").click();
 });
 
 Cypress.Commands.add("logout", (email, password) => {


### PR DESCRIPTION
- We do not need to simulate a user closing the toaster, as this is not
that common of a user interaction, fails intermittently locally, and
costs unnecessary build time

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?

- relates #XXX
-->
- fixes #2775 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
