### PR TITLE
1709 send feedbacks in report processes updates

### DIFF
--- a/backend/src/middleware/permissionsMiddleware.js
+++ b/backend/src/middleware/permissionsMiddleware.js
@@ -91,6 +91,7 @@ export default shield(
       Category: allow,
       Tag: allow,
       reports: isModerator,
+      filedReports: isAuthenticated,
       statistics: allow,
       currentUser: allow,
       Post: allow,

--- a/backend/src/schema/resolvers/reports.js
+++ b/backend/src/schema/resolvers/reports.js
@@ -24,7 +24,7 @@ export default {
             MATCH (resource {id: $resourceId})
             WHERE resource:User OR resource:Post OR resource:Comment
             MERGE (resource)<-[:BELONGS_TO]-(report:Report {closed: false})
-            ON CREATE SET report.id = randomUUID(), report.createdAt = $createdAt, report.updatedAt = report.createdAt, report.rule = 'latestReviewUpdatedAtRules', report.disable = resource.disabled, report.closed = false
+            ON CREATE SET report.id = randomUUID(), report.createdAt = $createdAt, report.updatedAt = report.createdAt, report.rule = 'latestReviewUpdatedAtRules', report.closed = false
             WITH submitter, resource, report
             CREATE (report)<-[filed:FILED {createdAt: $createdAt, reasonCategory: $reasonCategory, reasonDescription: $reasonDescription}]-(submitter)
 

--- a/backend/src/schema/types/type/Report.gql
+++ b/backend/src/schema/types/type/Report.gql
@@ -9,6 +9,13 @@ type Report {
   resource: ReportedResource
 }
 
+type FiledReport {
+  createdAt: String,
+  reasonDescription: String,
+  reasonCategory: String,
+  resource: ReportedResource,
+}
+
 union ReportedResource = User | Post | Comment
 
 enum ReportRule {
@@ -21,6 +28,7 @@ type Mutation {
 
 type Query {
   reports(orderBy: ReportOrdering, first: Int, offset: Int, reviewed: Boolean, closed: Boolean): [Report]
+  filedReports: [FiledReport]
 }
 
 enum ReportOrdering {

--- a/backend/src/schema/types/type/Report.gql
+++ b/backend/src/schema/types/type/Report.gql
@@ -3,7 +3,6 @@ type Report {
   createdAt: String!
   updatedAt: String!
   rule: ReportRule!
-  disable: Boolean!
   closed: Boolean!
   filed: [FILED]
   reviewed: [REVIEWED]!


### PR DESCRIPTION
## 🍰 Pullrequest
@Tirokk here are some proposed changes. @mattwr18 and I finally went the way to implement an extra resolver and a dedicated UI for the list of reported content. The turning point was when we wrote GraphQL statements manually and could see a long list of special cases that we would have to check if we expose graphlQL tye `Report` to any authenticated user. E.g. we would have to check that you cannot access `FILED` (or just one record) that `submitter` of `FILED` would not return `undefined`, etc.

So the suggestion is that we roughly implement this diagram:

![Untitled drawing](https://user-images.githubusercontent.com/2110676/74022002-ee4d7180-499c-11ea-8521-aa93a818edd8.png)

If you are the author of a reported content you will get a notification that points *to a resource* not a report. If you yourself have been blocked, you would see an error message on login.

