### PR TITLE
build(deps): Node v13 compatbility

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -129,5 +129,8 @@
     "prettier": "~1.19.1",
     "rosie": "^2.0.1",
     "supertest": "~4.0.2"
+  },
+  "resolutions": {
+    "fs-capacitor": "6.0.0"
   }
 }

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -4202,10 +4202,10 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
-fs-capacitor@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/fs-capacitor/-/fs-capacitor-2.0.4.tgz#5a22e72d40ae5078b4fe64fe4d08c0d3fc88ad3c"
-  integrity sha512-8S4f4WsCryNw2mJJchi46YgB6CR5Ze+4L1h8ewl9tEpL4SJ3ZO+c/bS4BWhB8bK+O3TMqhuZarTitd0S0eh2pA==
+fs-capacitor@6.0.0, fs-capacitor@^2.0.4:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/fs-capacitor/-/fs-capacitor-6.0.0.tgz#b4b89e3281d61df1c573e788d9ee6ec4c7c94da4"
+  integrity sha512-I+jZLV2q+ivQK/+Mu5FIYAECHgjoo8GBYJsBBQbNeU0aW1m25LU4E+MkLNq0kcJBjrp8Z6fhxpSeS8SyJyGkrw==
 
 fs-minipass@^1.2.5:
   version "1.2.6"
@@ -7923,6 +7923,11 @@ serve-static@1.14.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.14.1.tgz#666e636dc4f010f7ef29970a88a674320898b2f9"
   integrity sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==
+  dependencies:
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    parseurl "~1.3.3"
+    send "0.17.1"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## 🍰 Pullrequest
Force update of `fs-capacitor`, see https://github.com/jaydenseric/graphql-upload/issues/170#issue-527336432


### Issues
I am testing file uploads on my machine. My local `node` has version `v13.7.0`. This resolution fix does the trick for me.

