### PR TITLE
fix: Update devops_ticket.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/devops_ticket.md
+++ b/.github/ISSUE_TEMPLATE/devops_ticket.md
@@ -1,8 +1,8 @@
 ---
-name: :boom: DevOps ticket
+name: 💥 DevOps ticket
 about: Help us manage our deployed App.
 labels: devops
-title: :boom: [DevOps]
+title: 💥 [DevOps]
 ---
 
 ## :fire: DevOps ticket


### PR DESCRIPTION
This does not have an issue, but I think would be an exception... I can create an issue if others think it's necessary, but I have just copied and pasted an icon to the headers of the DevOps ticket issue template, which doesn't work with `:boom:`.
This is not code that will be deployed.