### PR TITLE
refactor(factories): Avoid unique constraint error

### DIFF
--- a/backend/src/db/factories.js
+++ b/backend/src/db/factories.js
@@ -27,7 +27,9 @@ export const cleanDatabase = async (options = {}) => {
 Factory.define('category')
   .attr('id', uuid)
   .attr('icon', 'globe')
-  .attr('name', 'global-peace-nonviolence')
+  .sequence('name', (i) => {
+    return `global-peace-nonviolence-${i}`
+  })
   .after((buildObject, options) => {
     return neode.create('Category', buildObject)
   })


### PR DESCRIPTION
## 🍰 Pullrequest
If @mattwr18's assumption is right that our build server is hanging
because we run into unique constraint errors then this should always
create a unique category slug for any created category along the way.

### Issues
Intermittently failing tests.
