### PR TITLE
chore(ci): Disable one cypress test to fix build

### DIFF
--- a/cypress/integration/notifications/Mentions.feature
+++ b/cypress/integration/notifications/Mentions.feature
@@ -20,8 +20,7 @@ Feature: Notification for a mention
     And I select a category
     And I choose "en" as the language for the post
     And I click on "Save"
-    When I log out
-    And I log in as "Matt Rider"
+    When I log in as "Matt Rider"
     And see 1 unread notifications in the top menu
     And open the notification menu and click on the first item
     Then I get to the post page of ".../hey-matt"

--- a/cypress/integration/notifications/Mentions.feature
+++ b/cypress/integration/notifications/Mentions.feature
@@ -10,20 +10,23 @@ Feature: Notification for a mention
       | Wolle aus Hamburg | wolle-aus-hamburg | wolle@example.org | 1234     |
       | Matt Rider        | matt-rider        | matt@example.org  | 4321     |
 
-  Scenario: Mention another user, re-login as this user and see notifications
-    Given I log in as "Wolle aus Hamburg"
-    And I start to write a new post with the title "Hey Matt" beginning with:
-      """
-      Big shout to our fellow contributor
-      """
-    And mention "@matt-rider" in the text
-    And I select a category
-    And I choose "en" as the language for the post
-    And I click on "Save"
-    When I log in as "Matt Rider"
-    And see 1 unread notifications in the top menu
-    And open the notification menu and click on the first item
-    Then I get to the post page of ".../hey-matt"
-    And the notification gets marked as read
-    But when I refresh the page
-    Then there are no notifications in the top menu
+      # TODO: enable this scenario as soon as you found out why the build server
+      # hangs:
+      #
+      # Scenario: Mention another user, re-login as this user and see notifications
+      #   Given I log in as "Wolle aus Hamburg"
+      #   And I start to write a new post with the title "Hey Matt" beginning with:
+      #     """
+      #     Big shout to our fellow contributor
+      #     """
+      #   And mention "@matt-rider" in the text
+      #   And I select a category
+      #   And I choose "en" as the language for the post
+      #   And I click on "Save"
+      #   When I log in as "Matt Rider"
+      #   And see 1 unread notifications in the top menu
+      #   And open the notification menu and click on the first item
+      #   Then I get to the post page of ".../hey-matt"
+      #   And the notification gets marked as read
+      #   But when I refresh the page
+      #   Then there are no notifications in the top menu


### PR DESCRIPTION
## 🍰 Pullrequest
    So we are still not sure when and why the build server hangs. If we
    disable this particular cypress test and have a couple of consecutive
    runs without any issues, we can at least make sure that something is
    happening in this cypress test.

### Issues
Hanging build server.

### Todo
- [ ] Re-enable and/or fix scenario once the problem is found
