### PR TITLE
chore(build): Fix uuid deprecations

### DIFF
--- a/backend/src/db/factories.js
+++ b/backend/src/db/factories.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid/v4'
+import { v4 as uuid } from 'uuid'
 import faker from 'faker'
 import slugify from 'slug'
 import { hashSync } from 'bcryptjs'

--- a/backend/src/models/Category.js
+++ b/backend/src/models/Category.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid/v4'
+import { v4 as uuid } from 'uuid'
 
 export default {
   id: { type: 'string', primary: true, default: uuid },

--- a/backend/src/models/Comment.js
+++ b/backend/src/models/Comment.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid/v4'
+import { v4 as uuid } from 'uuid'
 
 export default {
   id: { type: 'string', primary: true, default: uuid },

--- a/backend/src/models/Donations.js
+++ b/backend/src/models/Donations.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid/v4'
+import { v4 as uuid } from 'uuid'
 
 export default {
   id: { type: 'string', primary: true, default: uuid },

--- a/backend/src/models/Post.js
+++ b/backend/src/models/Post.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid/v4'
+import { v4 as uuid } from 'uuid'
 
 export default {
   id: { type: 'string', primary: true, default: uuid },

--- a/backend/src/models/Report.js
+++ b/backend/src/models/Report.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid/v4'
+import { v4 as uuid } from 'uuid'
 
 export default {
   id: { type: 'string', primary: true, default: uuid },

--- a/backend/src/models/SocialMedia.js
+++ b/backend/src/models/SocialMedia.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid/v4'
+import { v4 as uuid } from 'uuid'
 
 export default {
   id: { type: 'string', primary: true, default: uuid },

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid/v4'
+import { v4 as uuid } from 'uuid'
 
 export default {
   id: { type: 'string', primary: true, default: uuid }, // TODO: should be type: 'uuid' but simplified for our tests

--- a/backend/src/schema/resolvers/comments.js
+++ b/backend/src/schema/resolvers/comments.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid/v4'
+import { v4 as uuid } from 'uuid'
 import Resolver from './helpers/Resolver'
 
 export default {

--- a/backend/src/schema/resolvers/fileUpload/index.js
+++ b/backend/src/schema/resolvers/fileUpload/index.js
@@ -1,7 +1,7 @@
 import { createWriteStream } from 'fs'
 import path from 'path'
 import slug from 'slug'
-import uuid from 'uuid/v4'
+import { v4 as uuid } from 'uuid'
 
 const localFileUpload = async ({ createReadStream, uniqueFilename }) => {
   await new Promise((resolve, reject) =>

--- a/backend/src/schema/resolvers/helpers/generateNonce.js
+++ b/backend/src/schema/resolvers/helpers/generateNonce.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid/v4'
+import { v4 as uuid } from 'uuid'
 export default function generateNonce() {
   return uuid().substring(0, 6)
 }

--- a/backend/src/schema/resolvers/passwordReset.js
+++ b/backend/src/schema/resolvers/passwordReset.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid/v4'
+import { v4 as uuid } from 'uuid'
 import bcrypt from 'bcryptjs'
 import createPasswordReset from './helpers/createPasswordReset'
 

--- a/backend/src/schema/resolvers/posts.js
+++ b/backend/src/schema/resolvers/posts.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid/v4'
+import { v4 as uuid } from 'uuid'
 import { neo4jgraphql } from 'neo4j-graphql-js'
 import { isEmpty } from 'lodash'
 import { UserInputError } from 'apollo-server'


### PR DESCRIPTION
## 🍰 Pullrequest
```
(node:149) DeprecationWarning: Deep requiring like `const uuidv4 = require('uuid/v4');` is deprecated as of uuid@7.x. Please require the top-level module when using the Node.js CommonJS module or use ECMAScript Modules when bundling for the browser. See https://github.com/uuidjs/uuid/blob/master/README.md#upgrading-from-v3x-of-this-module for more information.
PASS src/schema/resolvers/follow.spec.js (5.295s)
(node:149) DeprecationWarning: Deep requiring like `const uuidv4 = require('uuid/v4');` is deprecated as of uuid@7.x. Please require the top-level module when using the Node.js CommonJS module or use ECMAScript Modules when bundling for the browser. See https://github.com/uuidjs/uuid/blob/master/README.md#upgrading-from-v3x-of-this-module for more information.
PASS src/middleware/permissionsMiddleware.spec.js (7.992s)
(node:149) DeprecationWarning: Deep requiring like `const uuidv4 = require('uuid/v4');` is deprecated as of uuid@7.x. Please require the top-level module when using the Node.js CommonJS module or use ECMAScript Modules when bundling for the browser. See https://github.com/uuidjs/uuid/blob/master/README.md#upgrading-from-v3x-of-this-module for more information.
PASS src/jwt/decode.spec.js
PASS src/schema/resolvers/embeds/findProvider.spec.js
PASS src/middleware/hashtags/extractHashtags.spec.js
(node:149) DeprecationWarning: Deep requiring like `const uuidv4 = require('uuid/v4');` is deprecated as of uuid@7.x. Please require the top-level module when using the Node.js CommonJS module or use ECMAScript Modules when bundling for the browser. See https://github.com/uuidjs/uuid/blob/master/README.md#upgrading-from-v3x-of-this-module for more information.
PASS src/schema/resolvers/statistics.spec.js (8.857s)
(node:149) DeprecationWarning: Deep requiring like `const uuidv4 = require('uuid/v4');` is deprecated as of uuid@7.x. Please require the top-level module when using the Node.js CommonJS module or use ECMAScript Modules when bundling for the browser. See https://github.com/uuidjs/uuid/blob/master/README.md#upgrading-from-v3x-of-this-module for more information.
PASS src/schema/resolvers/users/location.spec.js
PASS src/activitypub/security/httpSignature.spec.js
(node:149) DeprecationWarning: Deep requiring like `const uuidv4 = require('uuid/v4');` is deprecated as of uuid@7.x. Please require the top-level module when using the Node.js CommonJS module or use ECMAScript Modules when bundling for the browser. See https://github.com/uuidjs/uuid/blob/master/README.md#upgrading-from-v3x-of-this-module for more information.
PASS src/activitypub/routes/webfinger.spec.js
(node:149) DeprecationWarning: Deep requiring like `const uuidv4 = require('uuid/v4');` is deprecated as of uuid@7.x. Please require the top-level module when using the Node.js CommonJS module or use ECMAScript Modules when bundling for the browser. See https://github.com/uuidjs/uuid/blob/master/README.md#upgrading-from-v3x-of-this-module for more information.
PASS src/models/User.spec.js
(node:149) DeprecationWarning: Deep requiring like `const uuidv4 = require('uuid/v4');` is deprecated as of uuid@7.x. Please require the top-level module when using the Node.js CommonJS module or use ECMAScript Modules when bundling for the browser. See https://github.com/uuidjs/uuid/blob/master/README.md#upgrading-from-v3x-of-this-module for more information.
```
### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
