### PR TITLE
fix: Update user.updatedAt when password is reset

### DIFF
--- a/backend/src/schema/resolvers/passwordReset.js
+++ b/backend/src/schema/resolvers/passwordReset.js
@@ -22,6 +22,7 @@ export default {
               WHERE duration.between(passwordReset.issuedAt, datetime()).days <= 0 AND passwordReset.usedAt IS NULL
               SET passwordReset.usedAt = datetime()
               SET user.encryptedPassword = $encryptedNewPassword
+              SET user.updatedAt = toString(datetime())
               RETURN passwordReset
             `,
             {


### PR DESCRIPTION
- this is updating the user node, so it should update the updatedAt.
we recently ran into an issue where we weren't sure if a user had
successfully changed their password with the passwordReset, and needed
to look into it further to see if the PasswordReset had been used or not
to tell if it was successful.

