### PR TITLE
perf(neo4j): Improve currentUser read performance

### DIFF
--- a/backend/src/schema/types/type/User.gql
+++ b/backend/src/schema/types/type/User.gql
@@ -27,7 +27,7 @@ type User {
   id: ID!
   actorId: String
   name: String
-  email: String! @cypher(statement: "MATCH (this)-[: PRIMARY_EMAIL]->(e: EmailAddress) RETURN e.email")
+  email: String! @cypher(statement: "MATCH (this)-[:PRIMARY_EMAIL]->(e:EmailAddress) RETURN e.email")
   slug: String!
   avatar: String
   coverImg: String
@@ -38,7 +38,7 @@ type User {
   invitedBy: User @relation(name: "INVITED", direction: "IN")
   invited: [User] @relation(name: "INVITED", direction: "OUT")
 
-  location: Location @cypher(statement: "MATCH (this)-[: IS_IN]->(l: Location) RETURN l")
+  location: Location @cypher(statement: "MATCH (this)-[:IS_IN]->(l:Location) RETURN l")
   locationName: String
   about: String
   socialMedia: [SocialMedia]! @relation(name: "OWNED_BY", direction: "IN")
@@ -53,13 +53,13 @@ type User {
   showShoutsPublicly: Boolean
   locale: String
   friends: [User]! @relation(name: "FRIENDS", direction: "BOTH")
-  friendsCount: Int! @cypher(statement: "MATCH (this)<-[: FRIENDS]->(r: User) RETURN COUNT(DISTINCT r)")
+  friendsCount: Int! @cypher(statement: "MATCH (this)<-[:FRIENDS]->(r:User) RETURN COUNT(DISTINCT r)")
 
   following: [User]! @relation(name: "FOLLOWS", direction: "OUT")
-  followingCount: Int! @cypher(statement: "MATCH (this)-[: FOLLOWS]->(r: User) RETURN COUNT(DISTINCT r)")
+  followingCount: Int! @cypher(statement: "MATCH (this)-[:FOLLOWS]->(r:User) RETURN COUNT(DISTINCT r)")
 
   followedBy: [User]! @relation(name: "FOLLOWS", direction: "IN")
-  followedByCount: Int! @cypher(statement: "MATCH (this)<-[: FOLLOWS]-(r: User) RETURN COUNT(DISTINCT r)")
+  followedByCount: Int! @cypher(statement: "MATCH (this)<-[:FOLLOWS]-(r:User) RETURN COUNT(DISTINCT r)")
 
   # Is the currently logged in user following that user?
   followedByCurrentUser: Boolean! @cypher(
@@ -107,12 +107,12 @@ type User {
   commentedCount: Int! @cypher(statement: "MATCH (this)-[:WROTE]->(:Comment)-[:COMMENTS]->(p:Post) WHERE NOT p.deleted = true AND NOT p.disabled = true RETURN COUNT(DISTINCT(p))")
 
   shouted: [Post]! @relation(name: "SHOUTED", direction: "OUT")
-  shoutedCount: Int! @cypher(statement: "MATCH (this)-[: SHOUTED]->(r: Post) WHERE NOT r.deleted = true AND NOT r.disabled = true RETURN COUNT(DISTINCT r)")
+  shoutedCount: Int! @cypher(statement: "MATCH (this)-[:SHOUTED]->(r:Post) WHERE NOT r.deleted = true AND NOT r.disabled = true RETURN COUNT(DISTINCT r)")
 
   categories: [Category]! @relation(name: "CATEGORIZED", direction: "OUT")
 
   badges: [Badge]! @relation(name: "REWARDED", direction: "IN")
-  badgesCount: Int! @cypher(statement: "MATCH (this)<-[: REWARDED]-(r: Badge) RETURN COUNT(r)")
+  badgesCount: Int! @cypher(statement: "MATCH (this)<-[:REWARDED]-(r:Badge) RETURN COUNT(r)")
 
   emotions: [EMOTED]
 }

--- a/backend/src/schema/types/type/User.gql
+++ b/backend/src/schema/types/type/User.gql
@@ -97,14 +97,14 @@ type User {
   contributions: [Post]! @relation(name: "WROTE", direction: "OUT")
   contributionsCount: Int! @cypher(
   statement: """
-  MATCH (this)-[: WROTE]->(r: Post)
+  MATCH (this)-[:WROTE]->(r:Post)
   WHERE NOT r.deleted = true AND NOT r.disabled = true
   RETURN COUNT(r)
   """
   )
 
   comments: [Comment]! @relation(name: "WROTE", direction: "OUT")
-  commentedCount: Int! @cypher(statement: "MATCH (this)-[: WROTE]->(: Comment)-[: COMMENTS]->(p: Post) WHERE NOT p.deleted = true AND NOT p.disabled = true RETURN COUNT(DISTINCT(p))")
+  commentedCount: Int! @cypher(statement: "MATCH (this)-[:WROTE]->(:Comment)-[:COMMENTS]->(p:Post) WHERE NOT p.deleted = true AND NOT p.disabled = true RETURN COUNT(DISTINCT(p))")
 
   shouted: [Post]! @relation(name: "SHOUTED", direction: "OUT")
   shoutedCount: Int! @cypher(statement: "MATCH (this)-[: SHOUTED]->(r: Post) WHERE NOT r.deleted = true AND NOT r.disabled = true RETURN COUNT(DISTINCT r)")

--- a/webapp/graphql/User.js
+++ b/webapp/graphql/User.js
@@ -258,3 +258,24 @@ export const checkSlugAvailableQuery = gql`
     }
   }
 `
+
+export const currentUserQuery = gql`
+  ${userFragment}
+  query {
+    currentUser {
+      ...user
+      email
+      role
+      about
+      locationName
+      locale
+      allowEmbedIframes
+      showShoutsPublicly
+      termsAndConditionsAgreedVersion
+      socialMedia {
+        id
+        url
+      }
+    }
+  }
+`

--- a/webapp/store/auth.js
+++ b/webapp/store/auth.js
@@ -1,5 +1,6 @@
 import gql from 'graphql-tag'
 import { VERSION } from '~/constants/terms-and-conditions-version.js'
+import { currentUserQuery } from '~/graphql/User'
 
 export const state = () => {
   return {
@@ -72,32 +73,7 @@ export const actions = {
     const client = this.app.apolloProvider.defaultClient
     const {
       data: { currentUser },
-    } = await client.query({
-      query: gql`
-        query {
-          currentUser {
-            id
-            name
-            slug
-            email
-            avatar
-            role
-            about
-            locationName
-            locale
-            contributionsCount
-            commentedCount
-            allowEmbedIframes
-            showShoutsPublicly
-            termsAndConditionsAgreedVersion
-            socialMedia {
-              id
-              url
-            }
-          }
-        }
-      `,
-    })
+    } = await client.query({ query: currentUserQuery })
     if (!currentUser) return dispatch('logout')
     commit('SET_USER', currentUser)
     return currentUser


### PR DESCRIPTION
## 🍰 Pullrequest
This is a
* small refactoring, we want to keep all graphql in the frontend under `graphql`
* performance improvement, because we don't query for expensive user counts and avoid N+1 queries
* hopefully a fix for our user who receives 504 timeout for `currentUser` query.

### Issues
- fixes #3208 


### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
