### PR TITLE
refactor: deprecated slot syntax [2117]

### DIFF
--- a/webapp/components/CommentForm/CommentForm.vue
+++ b/webapp/components/CommentForm/CommentForm.vue
@@ -1,6 +1,6 @@
 <template>
   <ds-form v-model="form" @submit="handleSubmit" class="comment-form">
-    <template slot-scope="{ errors }">
+    <template #default="{ errors }">
       <base-card>
         <hc-editor ref="editor" :users="users" :value="form.content" @input="updateEditorContent" />
         <div class="buttons">

--- a/webapp/components/CommentForm/CommentForm.vue
+++ b/webapp/components/CommentForm/CommentForm.vue
@@ -1,6 +1,6 @@
 <template>
   <ds-form v-model="form" @submit="handleSubmit" class="comment-form">
-    <template v-slot="{ errors }">
+    <template slot-scope="{ errors }">
       <base-card>
         <hc-editor ref="editor" :users="users" :value="form.content" @input="updateEditorContent" />
         <div class="buttons">

--- a/webapp/components/CommentForm/CommentForm.vue
+++ b/webapp/components/CommentForm/CommentForm.vue
@@ -1,6 +1,6 @@
 <template>
   <ds-form v-model="form" @submit="handleSubmit" class="comment-form">
-    <template slot-scope="{ errors }">
+    <template v-slot="{ errors }">
       <base-card>
         <hc-editor ref="editor" :users="users" :value="form.content" @input="updateEditorContent" />
         <div class="buttons">

--- a/webapp/components/ContentMenu/ContentMenu.vue
+++ b/webapp/components/ContentMenu/ContentMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <dropdown class="content-menu" :placement="placement" offset="5">
-    <template slot="default" slot-scope="{ toggleMenu }">
+    <template v-slot="{ toggleMenu }">
       <slot name="button" :toggleMenu="toggleMenu">
         <base-button
           data-test="content-menu-button"

--- a/webapp/components/ContentMenu/ContentMenu.vue
+++ b/webapp/components/ContentMenu/ContentMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <dropdown class="content-menu" :placement="placement" offset="5">
-    <template slot="default" slot-scope="{ toggleMenu }">
+    <template #default="{ toggleMenu }">
       <slot name="button" :toggleMenu="toggleMenu">
         <base-button
           data-test="content-menu-button"

--- a/webapp/components/ContentMenu/ContentMenu.vue
+++ b/webapp/components/ContentMenu/ContentMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <dropdown class="content-menu" :placement="placement" offset="5">
-    <template v-slot="{ toggleMenu }">
+    <template slot="default" slot-scope="{ toggleMenu }">
       <slot name="button" :toggleMenu="toggleMenu">
         <base-button
           data-test="content-menu-button"

--- a/webapp/components/ContentMenu/ContentMenu.vue
+++ b/webapp/components/ContentMenu/ContentMenu.vue
@@ -15,15 +15,16 @@
     <template #popover="{ toggleMenu }">
       <div class="content-menu-popover">
         <ds-menu :routes="routes">
-          <ds-menu-item
-            #menuitem="item"
-            :route="item.route"
-            :parents="item.parents"
-            @click.stop.prevent="openItem(item.route, toggleMenu)"
-          >
-            <base-icon :name="item.route.icon" />
-            {{ item.route.label }}
-          </ds-menu-item>
+          <template #menuitem="item">
+            <ds-menu-item
+              :route="item.route"
+              :parents="item.parents"
+              @click.stop.prevent="openItem(item.route, toggleMenu)"
+            >
+              <base-icon :name="item.route.icon" />
+              {{ item.route.label }}
+            </ds-menu-item>
+          </template>
         </ds-menu>
       </div>
     </template>

--- a/webapp/components/ContentMenu/ContentMenu.vue
+++ b/webapp/components/ContentMenu/ContentMenu.vue
@@ -12,20 +12,21 @@
         />
       </slot>
     </template>
-    <div slot="popover" slot-scope="{ toggleMenu }" class="content-menu-popover">
-      <ds-menu :routes="routes">
-        <ds-menu-item
-          slot="menuitem"
-          slot-scope="item"
-          :route="item.route"
-          :parents="item.parents"
-          @click.stop.prevent="openItem(item.route, toggleMenu)"
-        >
-          <base-icon :name="item.route.icon" />
-          {{ item.route.label }}
-        </ds-menu-item>
-      </ds-menu>
-    </div>
+    <template #popover="{ toggleMenu }">
+      <div class="content-menu-popover">
+        <ds-menu :routes="routes">
+          <ds-menu-item
+            #menuitem="item"
+            :route="item.route"
+            :parents="item.parents"
+            @click.stop.prevent="openItem(item.route, toggleMenu)"
+          >
+            <base-icon :name="item.route.icon" />
+            {{ item.route.label }}
+          </ds-menu-item>
+        </ds-menu>
+      </div>
+    </template>
   </dropdown>
 </template>
 

--- a/webapp/components/ContributionForm/ContributionForm.vue
+++ b/webapp/components/ContributionForm/ContributionForm.vue
@@ -6,7 +6,7 @@
     :schema="formSchema"
     @submit="submit"
   >
-    <template slot-scope="{ errors }">
+    <template #default="{ errors }">
       <base-card>
         <template #heroImage>
           <img

--- a/webapp/components/ContributionForm/ContributionForm.vue
+++ b/webapp/components/ContributionForm/ContributionForm.vue
@@ -6,7 +6,7 @@
     :schema="formSchema"
     @submit="submit"
   >
-    <template slot-scope="{ errors }">
+    <template v-slot="{ errors }">
       <base-card>
         <template #heroImage>
           <img

--- a/webapp/components/ContributionForm/ContributionForm.vue
+++ b/webapp/components/ContributionForm/ContributionForm.vue
@@ -6,7 +6,7 @@
     :schema="formSchema"
     @submit="submit"
   >
-    <template v-slot="{ errors }">
+    <template slot-scope="{ errors }">
       <base-card>
         <template #heroImage>
           <img

--- a/webapp/components/DropdownFilter/DropdownFilter.vue
+++ b/webapp/components/DropdownFilter/DropdownFilter.vue
@@ -13,21 +13,20 @@
         <base-icon class="dropdown-arrow" name="angle-down" />
       </a>
     </template>
-    <ds-menu
-      #popover="{ toggleMenu }"
-      class="dropdown-menu-popover"
-      :routes="filterOptions"
-    >
-      <ds-menu-item
-        #menuitem="item"
-        class="dropdown-menu-item"
-        :route="item.route"
-        :parents="item.parents"
-        @click.stop.prevent="filter(item.route, toggleMenu)"
-      >
-        {{ item.route.label }}
-      </ds-menu-item>
-    </ds-menu>
+    <template #popover="{ toggleMenu }">
+      <ds-menu class="dropdown-menu-popover" :routes="filterOptions">
+        <template #menuitem="item">
+          <ds-menu-item
+            class="dropdown-menu-item"
+            :route="item.route"
+            :parents="item.parents"
+            @click.stop.prevent="filter(item.route, toggleMenu)"
+          >
+            {{ item.route.label }}
+          </ds-menu-item>
+        </template>
+      </ds-menu>
+    </template>
   </dropdown>
 </template>
 <script>

--- a/webapp/components/DropdownFilter/DropdownFilter.vue
+++ b/webapp/components/DropdownFilter/DropdownFilter.vue
@@ -1,18 +1,18 @@
 <template>
   <dropdown offset="8">
-    <a
-      :v-model="selected"
-      slot="default"
-      slot-scope="{ toggleMenu }"
-      name="dropdown"
-      class="dropdown-filter"
-      href="#"
-      @click.prevent="toggleMenu()"
-    >
-      <base-icon name="filter" />
-      <label class="label" for="dropdown">{{ selected }}</label>
-      <base-icon class="dropdown-arrow" name="angle-down" />
-    </a>
+    <template #default="{ toggleMenu }">
+      <a
+        :v-model="selected"
+        name="dropdown"
+        class="dropdown-filter"
+        href="#"
+        @click.prevent="toggleMenu()"
+      >
+        <base-icon name="filter" />
+        <label class="label" for="dropdown">{{ selected }}</label>
+        <base-icon class="dropdown-arrow" name="angle-down" />
+      </a>
+    </template>
     <ds-menu
       #popover="{ toggleMenu }"
       class="dropdown-menu-popover"

--- a/webapp/components/DropdownFilter/DropdownFilter.vue
+++ b/webapp/components/DropdownFilter/DropdownFilter.vue
@@ -1,18 +1,18 @@
 <template>
   <dropdown offset="8">
-    <a
-      :v-model="selected"
-      slot="default"
-      slot-scope="{ toggleMenu }"
-      name="dropdown"
-      class="dropdown-filter"
-      href="#"
-      @click.prevent="toggleMenu()"
-    >
-      <base-icon name="filter" />
-      <label class="label" for="dropdown">{{ selected }}</label>
-      <base-icon class="dropdown-arrow" name="angle-down" />
-    </a>
+    <template v-slot="{ toggleMenu }">
+      <a
+        :v-model="selected"
+        name="dropdown"
+        class="dropdown-filter"
+        href="#"
+        @click.prevent="toggleMenu()"
+      >
+        <base-icon name="filter" />
+        <label class="label" for="dropdown">{{ selected }}</label>
+        <base-icon class="dropdown-arrow" name="angle-down" />
+      </a>
+    </template>
     <ds-menu
       #popover="{ toggleMenu }"
       class="dropdown-menu-popover"

--- a/webapp/components/DropdownFilter/DropdownFilter.vue
+++ b/webapp/components/DropdownFilter/DropdownFilter.vue
@@ -1,18 +1,18 @@
 <template>
   <dropdown offset="8">
-    <template v-slot="{ toggleMenu }">
-      <a
-        :v-model="selected"
-        name="dropdown"
-        class="dropdown-filter"
-        href="#"
-        @click.prevent="toggleMenu()"
-      >
-        <base-icon name="filter" />
-        <label class="label" for="dropdown">{{ selected }}</label>
-        <base-icon class="dropdown-arrow" name="angle-down" />
-      </a>
-    </template>
+    <a
+      :v-model="selected"
+      slot="default"
+      slot-scope="{ toggleMenu }"
+      name="dropdown"
+      class="dropdown-filter"
+      href="#"
+      @click.prevent="toggleMenu()"
+    >
+      <base-icon name="filter" />
+      <label class="label" for="dropdown">{{ selected }}</label>
+      <base-icon class="dropdown-arrow" name="angle-down" />
+    </a>
     <ds-menu
       #popover="{ toggleMenu }"
       class="dropdown-menu-popover"

--- a/webapp/components/DropdownFilter/DropdownFilter.vue
+++ b/webapp/components/DropdownFilter/DropdownFilter.vue
@@ -14,14 +14,12 @@
       <base-icon class="dropdown-arrow" name="angle-down" />
     </a>
     <ds-menu
-      slot="popover"
-      slot-scope="{ toggleMenu }"
+      #popover="{ toggleMenu }"
       class="dropdown-menu-popover"
       :routes="filterOptions"
     >
       <ds-menu-item
-        slot="menuitem"
-        slot-scope="item"
+        #menuitem="item"
         class="dropdown-menu-item"
         :route="item.route"
         :parents="item.parents"

--- a/webapp/components/FilterPosts/FilterPosts.vue
+++ b/webapp/components/FilterPosts/FilterPosts.vue
@@ -1,10 +1,11 @@
 <template>
   <dropdown ref="menu" :placement="placement" :offset="offset">
     <base-button
-      v-slot="{ toggleMenu }"
+      slot="default"
       icon="filter"
       :filled="filterActive"
       :ghost="!filterActive"
+      slot-scope="{ toggleMenu }"
       @click.prevent="toggleMenu()"
     >
       <base-icon class="dropdown-arrow" name="angle-down" />

--- a/webapp/components/FilterPosts/FilterPosts.vue
+++ b/webapp/components/FilterPosts/FilterPosts.vue
@@ -1,15 +1,15 @@
 <template>
   <dropdown ref="menu" :placement="placement" :offset="offset">
-    <base-button
-      slot="default"
-      icon="filter"
-      :filled="filterActive"
-      :ghost="!filterActive"
-      slot-scope="{ toggleMenu }"
-      @click.prevent="toggleMenu()"
-    >
-      <base-icon class="dropdown-arrow" name="angle-down" />
-    </base-button>
+    <template #default="{ toggleMenu }">
+      <base-button
+        icon="filter"
+        :filled="filterActive"
+        :ghost="!filterActive"
+        @click.prevent="toggleMenu()"
+      >
+        <base-icon class="dropdown-arrow" name="angle-down" />
+      </base-button>
+    </template>
     <template slot="popover">
       <ds-container>
         <categories-filter-menu-items :chunk="chunk" />

--- a/webapp/components/FilterPosts/FilterPosts.vue
+++ b/webapp/components/FilterPosts/FilterPosts.vue
@@ -1,11 +1,10 @@
 <template>
   <dropdown ref="menu" :placement="placement" :offset="offset">
     <base-button
-      slot="default"
+      v-slot="{ toggleMenu }"
       icon="filter"
       :filled="filterActive"
       :ghost="!filterActive"
-      slot-scope="{ toggleMenu }"
       @click.prevent="toggleMenu()"
     >
       <base-icon class="dropdown-arrow" name="angle-down" />

--- a/webapp/components/LocaleSwitch/LocaleSwitch.vue
+++ b/webapp/components/LocaleSwitch/LocaleSwitch.vue
@@ -1,17 +1,17 @@
 <template>
   <client-only>
     <dropdown ref="menu" :placement="placement" :offset="offset">
-      <a
-        slot="default"
-        slot-scope="{ toggleMenu }"
-        class="locale-menu"
-        href="#"
-        @click.prevent="toggleMenu()"
-      >
-        <base-icon name="globe" />
-        <span class="label">{{ current.code.toUpperCase() }}</span>
-        <base-icon class="dropdown-arrow" name="angle-down" />
-      </a>
+      <template v-slot="{ toggleMenu }">
+        <a
+          class="locale-menu"
+          href="#"
+          @click.prevent="toggleMenu()"
+        >
+          <base-icon name="globe" />
+          <span class="label">{{ current.code.toUpperCase() }}</span>
+          <base-icon class="dropdown-arrow" name="angle-down" />
+        </a>
+      </template>
       <ds-menu
         #popover="{ toggleMenu }"
         class="locale-menu-popover"

--- a/webapp/components/LocaleSwitch/LocaleSwitch.vue
+++ b/webapp/components/LocaleSwitch/LocaleSwitch.vue
@@ -1,17 +1,17 @@
 <template>
   <client-only>
     <dropdown ref="menu" :placement="placement" :offset="offset">
-      <template v-slot="{ toggleMenu }">
-        <a
-          class="locale-menu"
-          href="#"
-          @click.prevent="toggleMenu()"
-        >
-          <base-icon name="globe" />
-          <span class="label">{{ current.code.toUpperCase() }}</span>
-          <base-icon class="dropdown-arrow" name="angle-down" />
-        </a>
-      </template>
+      <a
+        slot="default"
+        slot-scope="{ toggleMenu }"
+        class="locale-menu"
+        href="#"
+        @click.prevent="toggleMenu()"
+      >
+        <base-icon name="globe" />
+        <span class="label">{{ current.code.toUpperCase() }}</span>
+        <base-icon class="dropdown-arrow" name="angle-down" />
+      </a>
       <ds-menu
         #popover="{ toggleMenu }"
         class="locale-menu-popover"

--- a/webapp/components/LocaleSwitch/LocaleSwitch.vue
+++ b/webapp/components/LocaleSwitch/LocaleSwitch.vue
@@ -1,17 +1,13 @@
 <template>
   <client-only>
     <dropdown ref="menu" :placement="placement" :offset="offset">
-      <a
-        slot="default"
-        slot-scope="{ toggleMenu }"
-        class="locale-menu"
-        href="#"
-        @click.prevent="toggleMenu()"
-      >
-        <base-icon name="globe" />
-        <span class="label">{{ current.code.toUpperCase() }}</span>
-        <base-icon class="dropdown-arrow" name="angle-down" />
-      </a>
+      <template #default="{ toggleMenu }">
+        <a class="locale-menu" href="#" @click.prevent="toggleMenu()">
+          <base-icon name="globe" />
+          <span class="label">{{ current.code.toUpperCase() }}</span>
+          <base-icon class="dropdown-arrow" name="angle-down" />
+        </a>
+      </template>
       <ds-menu
         #popover="{ toggleMenu }"
         class="locale-menu-popover"

--- a/webapp/components/LocaleSwitch/LocaleSwitch.vue
+++ b/webapp/components/LocaleSwitch/LocaleSwitch.vue
@@ -8,22 +8,20 @@
           <base-icon class="dropdown-arrow" name="angle-down" />
         </a>
       </template>
-      <ds-menu
-        #popover="{ toggleMenu }"
-        class="locale-menu-popover"
-        :matcher="matcher"
-        :routes="routes"
-      >
-        <ds-menu-item
-          #menuitem="item"
-          class="locale-menu-item"
-          :route="item.route"
-          :parents="item.parents"
-          @click.stop.prevent="changeLanguage(item.route.path, toggleMenu)"
-        >
-          {{ item.route.name }}
-        </ds-menu-item>
-      </ds-menu>
+      <template #popover="{ toggleMenu }">
+        <ds-menu class="locale-menu-popover" :matcher="matcher" :routes="routes">
+          <template #menuitem="item">
+            <ds-menu-item
+              class="locale-menu-item"
+              :route="item.route"
+              :parents="item.parents"
+              @click.stop.prevent="changeLanguage(item.route.path, toggleMenu)"
+            >
+              {{ item.route.name }}
+            </ds-menu-item>
+          </template>
+        </ds-menu>
+      </template>
     </dropdown>
   </client-only>
 </template>

--- a/webapp/components/LocaleSwitch/LocaleSwitch.vue
+++ b/webapp/components/LocaleSwitch/LocaleSwitch.vue
@@ -13,15 +13,13 @@
         <base-icon class="dropdown-arrow" name="angle-down" />
       </a>
       <ds-menu
-        slot="popover"
-        slot-scope="{ toggleMenu }"
+        #popover="{ toggleMenu }"
         class="locale-menu-popover"
         :matcher="matcher"
         :routes="routes"
       >
         <ds-menu-item
-          slot="menuitem"
-          slot-scope="item"
+          #menuitem="item"
           class="locale-menu-item"
           :route="item.route"
           :parents="item.parents"

--- a/webapp/components/NotificationMenu/NotificationMenu.vue
+++ b/webapp/components/NotificationMenu/NotificationMenu.vue
@@ -7,7 +7,7 @@
     <base-button icon="bell" ghost circle />
   </nuxt-link>
   <dropdown v-else class="notifications-menu" offset="8" :placement="placement">
-    <template v-slot="{ toggleMenu }">
+    <template slot="default" slot-scope="{ toggleMenu }">
       <base-button @click="toggleMenu" ghost circle>
         <counter-icon icon="bell" :count="unreadNotificationsCount" danger />
       </base-button>

--- a/webapp/components/NotificationMenu/NotificationMenu.vue
+++ b/webapp/components/NotificationMenu/NotificationMenu.vue
@@ -7,7 +7,7 @@
     <base-button icon="bell" ghost circle />
   </nuxt-link>
   <dropdown v-else class="notifications-menu" offset="8" :placement="placement">
-    <template slot="default" slot-scope="{ toggleMenu }">
+    <template #default="{ toggleMenu }">
       <base-button @click="toggleMenu" ghost circle>
         <counter-icon icon="bell" :count="unreadNotificationsCount" danger />
       </base-button>

--- a/webapp/components/NotificationMenu/NotificationMenu.vue
+++ b/webapp/components/NotificationMenu/NotificationMenu.vue
@@ -7,7 +7,7 @@
     <base-button icon="bell" ghost circle />
   </nuxt-link>
   <dropdown v-else class="notifications-menu" offset="8" :placement="placement">
-    <template slot="default" slot-scope="{ toggleMenu }">
+    <template v-slot="{ toggleMenu }">
       <base-button @click="toggleMenu" ghost circle>
         <counter-icon icon="bell" :count="unreadNotificationsCount" danger />
       </base-button>

--- a/webapp/components/Password/Change.vue
+++ b/webapp/components/Password/Change.vue
@@ -1,6 +1,6 @@
 <template>
   <ds-form v-model="formData" :schema="formSchema" @submit="handleSubmit">
-    <template v-slot="{ errors }">
+    <template slot-scope="{ errors }">
       <ds-input
         id="oldPassword"
         model="oldPassword"

--- a/webapp/components/Password/Change.vue
+++ b/webapp/components/Password/Change.vue
@@ -1,6 +1,6 @@
 <template>
   <ds-form v-model="formData" :schema="formSchema" @submit="handleSubmit">
-    <template slot-scope="{ errors }">
+    <template #default="{ errors }">
       <ds-input
         id="oldPassword"
         model="oldPassword"

--- a/webapp/components/Password/Change.vue
+++ b/webapp/components/Password/Change.vue
@@ -1,6 +1,6 @@
 <template>
   <ds-form v-model="formData" :schema="formSchema" @submit="handleSubmit">
-    <template slot-scope="{ errors }">
+    <template v-slot="{ errors }">
       <ds-input
         id="oldPassword"
         model="oldPassword"

--- a/webapp/components/PasswordReset/ChangePassword.vue
+++ b/webapp/components/PasswordReset/ChangePassword.vue
@@ -7,7 +7,7 @@
       @submit="handleSubmitPassword"
       class="change-password"
     >
-      <template slot-scope="{ errors }">
+      <template v-slot="{ errors }">
         <ds-input
           id="password"
           model="password"

--- a/webapp/components/PasswordReset/ChangePassword.vue
+++ b/webapp/components/PasswordReset/ChangePassword.vue
@@ -7,7 +7,7 @@
       @submit="handleSubmitPassword"
       class="change-password"
     >
-      <template v-slot="{ errors }">
+      <template slot-scope="{ errors }">
         <ds-input
           id="password"
           model="password"

--- a/webapp/components/PasswordReset/ChangePassword.vue
+++ b/webapp/components/PasswordReset/ChangePassword.vue
@@ -7,7 +7,7 @@
       @submit="handleSubmitPassword"
       class="change-password"
     >
-      <template slot-scope="{ errors }">
+      <template #default="{ errors }">
         <ds-input
           id="password"
           model="password"

--- a/webapp/pages/admin/categories.vue
+++ b/webapp/pages/admin/categories.vue
@@ -2,7 +2,7 @@
   <base-card>
     <h2 class="title">{{ $t('admin.categories.name') }}</h2>
     <ds-table :data="Category" :fields="fields" condensed>
-      <template slot="icon" slot-scope="scope">
+      <template #icon="scope">
         <base-icon :name="scope.row.icon" />
       </template>
     </ds-table>

--- a/webapp/pages/admin/hashtags.vue
+++ b/webapp/pages/admin/hashtags.vue
@@ -2,8 +2,8 @@
   <base-card>
     <h2 class="title">{{ $t('admin.hashtags.name') }}</h2>
     <ds-table :data="Tag" :fields="fields" condensed>
-      <template slot="index" slot-scope="scope">{{ scope.index + 1 }}.</template>
-      <template slot="id" slot-scope="scope">
+      <template #index="scope">{{ scope.index + 1 }}.</template>
+      <template #id="scope">
         <nuxt-link :to="{ path: '/', query: { hashtag: encodeURI(scope.row.id) } }">
           <b>#{{ scope.row.id | truncate(20) }}</b>
         </nuxt-link>

--- a/webapp/pages/admin/users.vue
+++ b/webapp/pages/admin/users.vue
@@ -19,8 +19,8 @@
     </base-card>
     <base-card v-if="User && User.length">
       <ds-table :data="User" :fields="fields" condensed>
-        <template slot="index" slot-scope="scope">{{ scope.row.index + 1 }}.</template>
-        <template slot="name" slot-scope="scope">
+        <template #index="scope">{{ scope.row.index + 1 }}.</template>
+        <template #name="scope">
           <nuxt-link
             :to="{
               name: 'profile-id-slug',
@@ -30,12 +30,12 @@
             <b>{{ scope.row.name | truncate(20) }}</b>
           </nuxt-link>
         </template>
-        <template slot="email" slot-scope="scope">
+        <template #email="scope">
           <a :href="`mailto:${scope.row.email}`">
             <b>{{ scope.row.email }}</b>
           </a>
         </template>
-        <template slot="slug" slot-scope="scope">
+        <template #slug="scope">
           <nuxt-link
             :to="{
               name: 'profile-id-slug',
@@ -45,7 +45,7 @@
             <b>{{ scope.row.slug | truncate(20) }}</b>
           </nuxt-link>
         </template>
-        <template slot="createdAt" slot-scope="scope">
+        <template #createdAt="scope">
           {{ scope.row.createdAt | dateTime }}
         </template>
       </ds-table>

--- a/webapp/pages/settings/index.vue
+++ b/webapp/pages/settings/index.vue
@@ -1,6 +1,6 @@
 <template>
   <ds-form v-model="form" :schema="formSchema" @submit="submit">
-    <template v-slot="{ errors }">
+    <template slot-scope="{ errors }">
       <base-card>
         <h2 class="title">{{ $t('settings.data.name') }}</h2>
         <ds-input

--- a/webapp/pages/settings/index.vue
+++ b/webapp/pages/settings/index.vue
@@ -1,6 +1,6 @@
 <template>
   <ds-form v-model="form" :schema="formSchema" @submit="submit">
-    <template slot-scope="{ errors }">
+    <template #default="{ errors }">
       <base-card>
         <h2 class="title">{{ $t('settings.data.name') }}</h2>
         <ds-input

--- a/webapp/pages/settings/index.vue
+++ b/webapp/pages/settings/index.vue
@@ -1,6 +1,6 @@
 <template>
   <ds-form v-model="form" :schema="formSchema" @submit="submit">
-    <template slot-scope="{ errors }">
+    <template v-slot="{ errors }">
       <base-card>
         <h2 class="title">{{ $t('settings.data.name') }}</h2>
         <ds-input

--- a/webapp/pages/settings/my-email-address/enter-nonce.vue
+++ b/webapp/pages/settings/my-email-address/enter-nonce.vue
@@ -1,6 +1,6 @@
 <template>
   <ds-form v-model="form" :schema="formSchema" @submit="submit">
-    <template v-slot="{ errors }">
+    <template slot-scope="{ errors }">
       <base-card>
         <h2 class="title">{{ $t('settings.email.name') }}</h2>
         <ds-input

--- a/webapp/pages/settings/my-email-address/enter-nonce.vue
+++ b/webapp/pages/settings/my-email-address/enter-nonce.vue
@@ -1,6 +1,6 @@
 <template>
   <ds-form v-model="form" :schema="formSchema" @submit="submit">
-    <template slot-scope="{ errors }">
+    <template #default="{ errors }">
       <base-card>
         <h2 class="title">{{ $t('settings.email.name') }}</h2>
         <ds-input

--- a/webapp/pages/settings/my-email-address/enter-nonce.vue
+++ b/webapp/pages/settings/my-email-address/enter-nonce.vue
@@ -1,6 +1,6 @@
 <template>
   <ds-form v-model="form" :schema="formSchema" @submit="submit">
-    <template slot-scope="{ errors }">
+    <template v-slot="{ errors }">
       <base-card>
         <h2 class="title">{{ $t('settings.email.name') }}</h2>
         <ds-input

--- a/webapp/pages/settings/my-email-address/index.vue
+++ b/webapp/pages/settings/my-email-address/index.vue
@@ -6,7 +6,7 @@
     <ds-text v-html="submitMessage" />
   </base-card>
   <ds-form v-else v-model="form" :schema="formSchema" @submit="submit">
-    <template slot-scope="{ errors }">
+    <template v-slot="{ errors }">
       <base-card>
         <h2 class="title">{{ $t('settings.email.name') }}</h2>
         <ds-input

--- a/webapp/pages/settings/my-email-address/index.vue
+++ b/webapp/pages/settings/my-email-address/index.vue
@@ -6,7 +6,7 @@
     <ds-text v-html="submitMessage" />
   </base-card>
   <ds-form v-else v-model="form" :schema="formSchema" @submit="submit">
-    <template slot-scope="{ errors }">
+    <template #default="{ errors }">
       <base-card>
         <h2 class="title">{{ $t('settings.email.name') }}</h2>
         <ds-input

--- a/webapp/pages/settings/my-email-address/index.vue
+++ b/webapp/pages/settings/my-email-address/index.vue
@@ -6,7 +6,7 @@
     <ds-text v-html="submitMessage" />
   </base-card>
   <ds-form v-else v-model="form" :schema="formSchema" @submit="submit">
-    <template v-slot="{ errors }">
+    <template slot-scope="{ errors }">
       <base-card>
         <h2 class="title">{{ $t('settings.email.name') }}</h2>
         <ds-input

--- a/webapp/vue.md
+++ b/webapp/vue.md
@@ -3,6 +3,7 @@
 ## We use single-file components
 
 Each component lives in a single file, containing:
+
 - its `template` (the DOM structure)
 - its `script` (including `props`, `data` and `methods` among other things)
 - its `style` (defining the look of the component)
@@ -10,6 +11,7 @@ Each component lives in a single file, containing:
 See the [Vue.js docs](https://vuejs.org/v2/guide/single-file-components.html) for more details.
 
 Placed in the same folder are also:
+
 - the test file (e.g. `MyComponent.spec.js`)
 - the storybook file (e.g. `MyComponent.story.js`)
 
@@ -20,6 +22,7 @@ Vue.js allows us to define component props either as strings or as objects (with
 Also: only (and always!) define a `default` for props that are _not required_.
 
 Why?
+
 - it makes our code more robust – a warning will be shown when passing a wrong prop type
 - it clearly defines the component API and tells other developers how to use it
 
@@ -43,11 +46,14 @@ For more complex use cases see the [official Vue.js documentation](https://vuejs
 ## We use shorthands
 
 For better readability we prefer
+
 - `:something` over `v-bind:something`
 - `@click` over `v-on:click`
+- `#slotSame` over `v-slot:slotName`
+- `#default` over `v-slot`
 
-Read more in the [official Vue.js docs](https://vuejs.org/v2/guide/syntax.html#Shorthands)
+Read more in the [official Vue.js docs](https://vuejs.org/v2/guide/syntax.html#Shorthands) (for [slots](https://vuejs.org/v2/guide/components-slots.html#Named-Slots-Shorthand))
 
 ## Recommended reads
 
-The [Vue.js component style guide](https://pablohpsilva.github.io/vuejs-component-style-guide/#/?id=harness-your-component-props) offers a whole list of best-practices for writing Vue components. 
+The [Vue.js component style guide](https://pablohpsilva.github.io/vuejs-component-style-guide/#/?id=harness-your-component-props) offers a whole list of best-practices for writing Vue components.


### PR DESCRIPTION
## 🍰 Pullrequest

> Following https://vuejs.org/v2/guide/components-slots.htmlNamed-Slots
We are using deprecated syntax in various places in our code base
In short, <template slot="index" slot-scope="scope"\> can be refactored to <template #index="scope"\>
Motivation for this change, and more examples can be found here https://github.com/vuejs/rfcs/blob/master/active-rfcs/0001-new-slot-syntax.md

### Issues

- addresses #2117 

### Todo
1. [x] use shorthand for default slots
2. [x] ~Some test failures are seemingly caused by <ds-*> not handling the new syntax well. If so, and since they are supposed to be refactored out anyway, this might be a blocker.~
Turns out, components are not the cause. Just didn't understand the new syntax, fully. ([see comment](https://github.com/Human-Connection/Human-Connection/pull/3258#issuecomment-598454126))