### PR TITLE
fix: Text of editor embeds disappearing on click [2727]

### DIFF
--- a/webapp/components/Editor/nodes/LegacyEmbed.js
+++ b/webapp/components/Editor/nodes/LegacyEmbed.js
@@ -40,6 +40,7 @@ export default class Embed extends Node {
       },
       group: 'inline',
       inline: true,
+      selectable: false,
       parseDOM: [
         {
           tag: 'a[href].embed',


### PR DESCRIPTION
## 🍰 Pullrequest
### Problem
[EmbedComponent](https://github.com/Human-Connection/Human-Connection/blob/fbcc10ef0d6cbca69cfc75689dfbf23103cb1d91/webapp/components/Embed/EmbedComponent.vue) is inserted as editor content (inside `<p>`) and selected with a [NodeSelection](https://prosemirror.net/docs/ref/#state.NodeSelection) @click. 

![click-selects](https://user-images.githubusercontent.com/3411649/77723470-d84d4c00-6ff0-11ea-897a-71b1dad2c3e6.png)

Changing the schema of the [Embed](https://github.com/Human-Connection/Human-Connection/blob/fbcc10ef0d6cbca69cfc75689dfbf23103cb1d91/webapp/components/Editor/nodes/Embed.js#L42) Node has no effect for
- `selectable: false`
- `atom: true`
- `marks: ''`

(see prosemirror [NodeSpec](https://prosemirror.net/docs/ref/#model.NodeSpec))

### Workaround
fbcc10e - Prevent selection in entire embed element. This has the obvious downside that no content can be selected for e.g. copying.

### Packages
- [tiptap](https://github.com/scrumpy/tiptap)
  - [prosemirror](https://prosemirror.net/) editor

### Issues
- fixes #2727 

### Todo
- [x] find solution, i.e. learn how [Prosemirror](https://prosemirror.net/docs/ref/#top.intro) works