### PR TITLE
feat: [wip] autosave drafts [3252]

### DIFF
--- a/webapp/components/Editor/Editor.spec.js
+++ b/webapp/components/Editor/Editor.spec.js
@@ -161,14 +161,14 @@ describe('Editor.vue', () => {
     beforeAll(() => jest.useFakeTimers())
     afterAll(() => jest.useRealTimers())
 
-    describe('when false', () => {
+    describe('when false (default)', () => {
       const content = '<p>NOOP WIP</p>'
 
       beforeEach(async () => {
         propsData = {
           // <hc-editor :autosave="false" />
           // plugin ignores all changes (transactions) on this instance
-          autosave: false,
+          // autosave: false (default)
         }
         mocks = {
           $t: (t) => t,
@@ -192,7 +192,7 @@ describe('Editor.vue', () => {
 
       beforeEach(async () => {
         propsData = {
-          // :autosave defaults to true
+          autosave: true,
         }
         mocks = {
           $t: (t) => t,
@@ -239,7 +239,9 @@ describe('Editor.vue', () => {
       const content = '<p>Comment WIP</p>'
 
       beforeEach(async () => {
-        propsData = {}
+        propsData = {
+          autosave: true,
+        }
         mocks = {
           $t: (t) => t,
         }

--- a/webapp/components/Editor/Editor.spec.js
+++ b/webapp/components/Editor/Editor.spec.js
@@ -31,15 +31,15 @@ describe('Editor.vue', () => {
     }))
   }
 
-  beforeEach(() => {
-    propsData = {}
-    mocks = {
-      $t: () => 'some cool placeholder',
-    }
-    wrapper = Wrapper()
-  })
-
   describe('mount', () => {
+    beforeEach(() => {
+      propsData = {}
+      mocks = {
+        $t: () => 'some cool placeholder',
+      }
+      wrapper = Wrapper()
+    })
+
     it('renders', () => {
       expect(Wrapper().is('div')).toBe(true)
     })
@@ -149,7 +149,7 @@ describe('Editor.vue', () => {
   })
 
   describe(':autosave', () => {
-    const getFirst = () => {
+    const getFirstInStorage = () => {
       const storageKey = Object.keys(localStorage)[0]
       const value = localStorage[storageKey]
       return {
@@ -165,9 +165,16 @@ describe('Editor.vue', () => {
       let routerWrapper
 
       beforeEach(() => {
+        propsData = {}
+        mocks = {
+          $t: (key) => key,
+        }
         router = new VueRouter({
           routes: [{ path: 'post/create' }],
         })
+        mocks = {
+          $t: (key) => key,
+        }
         router.push('/post/create')
         propsData.autosave = false
         routerWrapper = Wrapper()
@@ -187,6 +194,10 @@ describe('Editor.vue', () => {
       const content = '<p>Post WIP</p>'
 
       beforeEach(async () => {
+        propsData = {}
+        mocks = {
+          $t: (key) => key,
+        }
         router = new VueRouter({
           routes: [{ path: 'post/create' }],
         })
@@ -201,7 +212,7 @@ describe('Editor.vue', () => {
       })
 
       it('saves editor content to localStorage on input', async () => {
-        const { storageKey, value } = getFirst()
+        const { storageKey, value } = getFirstInStorage()
         expect(storageKey.startsWith('draft:post:')).toBe(true)
         expect(value).toBe(content)
       })
@@ -212,6 +223,10 @@ describe('Editor.vue', () => {
       const content = '<p>Comment WIP</p>'
 
       beforeEach(async () => {
+        propsData = {}
+        mocks = {
+          $t: (key) => key,
+        }
         router = new VueRouter({
           routes: [{ path: `/post/${postId}/foo-title-slug` }],
         })
@@ -221,14 +236,20 @@ describe('Editor.vue', () => {
         await jest.runAllTimers()
       })
 
-      afterEach(() => {
+      afterAll(() => {
         localStorage.clear()
       })
 
       it('saves editor content to localStorage on input', async () => {
-        const { storageKey, value } = getFirst()
+        const { storageKey, value } = getFirstInStorage()
         expect(storageKey).toBe(`draft:${postId}`)
         expect(value).toBe(content)
+      })
+
+      it('loads an existing autosave', () => {
+        const { value: autoSaveHTML } = getFirstInStorage()
+        const _wrapper = Wrapper()
+        expect(_wrapper.vm.editor.getHTML()).toBe(autoSaveHTML)
       })
     })
   })

--- a/webapp/components/Editor/Editor.spec.js
+++ b/webapp/components/Editor/Editor.spec.js
@@ -35,7 +35,7 @@ describe('Editor.vue', () => {
     beforeEach(() => {
       propsData = {}
       mocks = {
-        $t: () => 'some cool placeholder',
+        $t: (t) => t,
       }
       wrapper = Wrapper()
     })
@@ -59,7 +59,7 @@ describe('Editor.vue', () => {
 
     it('translates the placeholder', () => {
       expect(wrapper.vm.editor.extensions.options.placeholder.emptyNodeText).toEqual(
-        'some cool placeholder',
+        'editor.placeholder',
       )
     })
 
@@ -162,30 +162,27 @@ describe('Editor.vue', () => {
     afterAll(() => jest.useRealTimers())
 
     describe('when false', () => {
-      let routerWrapper
+      const content = '<p>NOOP WIP</p>'
 
-      beforeEach(() => {
-        propsData = {}
-        mocks = {
-          $t: (key) => key,
+      beforeEach(async () => {
+        propsData = {
+          // <hc-editor :autosave="false" />
+          // plugin ignores all changes (transactions) on this instance
+          autosave: false,
         }
-        router = new VueRouter({
-          routes: [{ path: 'post/create' }],
-        })
         mocks = {
-          $t: (key) => key,
+          $t: (t) => t,
         }
-        router.push('/post/create')
-        propsData.autosave = false
-        routerWrapper = Wrapper()
+
+        // testing against localStorage, so letting
+        // the editor do its thing without keeping
+        // a reference is enough
+        Wrapper().vm.editor.setContent(content, true)
+
+        await jest.runAllTimers()
       })
 
       it('does nothing', () => {
-        const content = '<p>NOOP WIP</p>'
-
-        routerWrapper.vm.editor.setContent(content, true)
-        jest.runAllTimers()
-
         expect(Object.keys(localStorage).length).toBe(0)
       })
     })
@@ -194,10 +191,14 @@ describe('Editor.vue', () => {
       const content = '<p>Post WIP</p>'
 
       beforeEach(async () => {
-        propsData = {}
-        mocks = {
-          $t: (key) => key,
+        propsData = {
+          // :autosave defaults to true
         }
+        mocks = {
+          $t: (t) => t,
+        }
+
+        // plugin creates storage ids from $route.path
         router = new VueRouter({
           routes: [{ path: 'post/create' }],
         })
@@ -225,13 +226,12 @@ describe('Editor.vue', () => {
       beforeEach(async () => {
         propsData = {}
         mocks = {
-          $t: (key) => key,
+          $t: (t) => t,
         }
         router = new VueRouter({
           routes: [{ path: `/post/${postId}/foo-title-slug` }],
         })
         router.push(`/post/${postId}/foo-title-slug`)
-
         Wrapper().vm.editor.setContent(content, true)
         await jest.runAllTimers()
       })
@@ -247,9 +247,9 @@ describe('Editor.vue', () => {
       })
 
       it('loads an existing autosave', () => {
-        const { value: autoSaveHTML } = getFirstInStorage()
+        const { value: autosaveHTML } = getFirstInStorage()
         const _wrapper = Wrapper()
-        expect(_wrapper.vm.editor.getHTML()).toBe(autoSaveHTML)
+        expect(_wrapper.vm.editor.getHTML()).toBe(autosaveHTML)
       })
     })
   })

--- a/webapp/components/Editor/Editor.spec.js
+++ b/webapp/components/Editor/Editor.spec.js
@@ -208,14 +208,23 @@ describe('Editor.vue', () => {
         await jest.runAllTimers()
       })
 
-      afterEach(() => {
+      afterAll(() => {
         localStorage.clear()
       })
 
       it('saves editor content to localStorage on input', async () => {
-        const { storageKey, value } = getFirstInStorage()
-        expect(storageKey.startsWith('draft:post:')).toBe(true)
+        const { value } = getFirstInStorage()
         expect(value).toBe(content)
+      })
+
+      it('generates a temporary id for the post', () => {
+        const { storageKey } = getFirstInStorage()
+        expect(storageKey).toMatch(/^autosave:post:[a-f\d]{8}$/)
+      })
+
+      it('stores temporary id of last edit', () => {
+        const lastEditedId = localStorage.getItem('autosave:post:last')
+        expect(lastEditedId).toMatch(/^[a-f\d]{8}$/)
       })
     })
 
@@ -242,7 +251,7 @@ describe('Editor.vue', () => {
 
       it('saves editor content to localStorage on input', async () => {
         const { storageKey, value } = getFirstInStorage()
-        expect(storageKey).toBe(`draft:${postId}`)
+        expect(storageKey).toMatch(/autosave:comment:[a-f\d]{8}/)
         expect(value).toBe(content)
       })
 

--- a/webapp/components/Editor/Editor.spec.js
+++ b/webapp/components/Editor/Editor.spec.js
@@ -226,6 +226,12 @@ describe('Editor.vue', () => {
         const lastEditedId = localStorage.getItem('autosave:post:last')
         expect(lastEditedId).toMatch(/^[a-f\d]{8}$/)
       })
+
+      it('loads last edited autosave', () => {
+        const wrapper = Wrapper()
+        const { value: autosaveHTML } = getFirstInStorage()
+        expect(wrapper.vm.editor.getHTML()).toBe(autosaveHTML)
+      })
     })
 
     describe('when editing a comment', () => {

--- a/webapp/components/Editor/Editor.story.js
+++ b/webapp/components/Editor/Editor.story.js
@@ -1,5 +1,6 @@
 import { storiesOf } from '@storybook/vue'
 import { withA11y } from '@storybook/addon-a11y'
+import StoryRouter from 'storybook-vue-router'
 import HcEditor from '~/components/Editor/Editor.vue'
 import helpers from '~/storybook/helpers'
 import Vue from 'vue'
@@ -35,6 +36,7 @@ const users = [
 
 storiesOf('Editor', module)
   .addDecorator(withA11y)
+  .addDecorator(StoryRouter())
   .addDecorator((storyFn) => {
     const ctx = storyFn()
     return {

--- a/webapp/components/Editor/Editor.story.js
+++ b/webapp/components/Editor/Editor.story.js
@@ -36,18 +36,7 @@ const users = [
 
 storiesOf('Editor', module)
   .addDecorator(withA11y)
-  .addDecorator(StoryRouter())
-  .addDecorator((storyFn) => {
-    const ctx = storyFn()
-    return {
-      components: { ctx },
-      template: `
-        <base-card style="width: 50%; min-width: 500px; margin: 0 auto;">
-          <ctx />
-        </base-card>
-      `,
-    }
-  })
+  .addDecorator(helpers.wrapInCard)
   .addDecorator(helpers.layout)
   .add('Empty', () => ({
     components: { HcEditor },
@@ -149,4 +138,44 @@ storiesOf('Editor', module)
       `,
     }),
     template: `<hc-editor :users="users" :value="content" />`,
+  }))
+
+storiesOf('Editor/AutoSave', module)
+  .addDecorator(
+    StoryRouter(
+      {},
+      {
+        initialEntry: '/post/create',
+      },
+    ),
+  )
+  .addDecorator(helpers.wrapInCard)
+  .addDecorator(helpers.layout)
+  .add('creating a post', () => ({
+    components: { HcEditor },
+    store: helpers.store,
+    data: () => ({
+      users,
+    }),
+    template: `<hc-editor :users="users" />`,
+  }))
+
+storiesOf('Editor/AutoSave', module)
+  .addDecorator(
+    StoryRouter(
+      {},
+      {
+        initialEntry: '/post/f00-b00-1d/post-slug-I-comment-on',
+      },
+    ),
+  )
+  .addDecorator(helpers.wrapInCard)
+  .addDecorator(helpers.layout)
+  .add('creating a comment', () => ({
+    components: { HcEditor },
+    store: helpers.store,
+    data: () => ({
+      users,
+    }),
+    template: `<hc-editor :users="users" />`,
   }))

--- a/webapp/components/Editor/Editor.vue
+++ b/webapp/components/Editor/Editor.vue
@@ -29,6 +29,9 @@ import { replace, build } from 'xregexp/xregexp-all.js'
 import * as key from '../../constants/keycodes'
 import { HASHTAG, MENTION } from '../../constants/editor'
 import defaultExtensions from './defaultExtensions.js'
+
+import AutoSave from './plugins/autoSave.js'
+
 import EventHandler from './plugins/eventHandler.js'
 import Hashtag from './nodes/Hashtag.js'
 import Mention from './nodes/Mention.js'
@@ -50,9 +53,12 @@ export default {
   props: {
     users: { type: Array, default: () => null }, // If 'null', than the Mention extention is not assigned.
     hashtags: { type: Array, default: () => null }, // If 'null', than the Hashtag extention is not assigned.
-    value: { type: String, default: '' },
     doc: { type: Object, default: () => {} },
     autosave: { type: Boolean, default: true },
+    value: {
+      type: String,
+      default: '',
+    },
   },
   data() {
     return {
@@ -106,6 +112,9 @@ export default {
       }
       return extensions
     },
+    autosaveContent() {
+      return this.autosave && this.$route ? AutoSave.load(this.$route.path) : ''
+    },
   },
   watch: {
     placeholder: {
@@ -120,7 +129,7 @@ export default {
   },
   mounted() {
     this.editor = new Editor({
-      content: this.value || '',
+      content: this.value || this.autosaveContent || '',
       doc: this.doc,
       extensions: [
         // Hashtags must come first, see

--- a/webapp/components/Editor/Editor.vue
+++ b/webapp/components/Editor/Editor.vue
@@ -52,6 +52,7 @@ export default {
     hashtags: { type: Array, default: () => null }, // If 'null', than the Hashtag extention is not assigned.
     value: { type: String, default: '' },
     doc: { type: Object, default: () => {} },
+    autosave: { type: Boolean, default: true },
   },
   data() {
     return {

--- a/webapp/components/Editor/Editor.vue
+++ b/webapp/components/Editor/Editor.vue
@@ -54,7 +54,7 @@ export default {
     users: { type: Array, default: () => null }, // If 'null', than the Mention extention is not assigned.
     hashtags: { type: Array, default: () => null }, // If 'null', than the Hashtag extention is not assigned.
     doc: { type: Object, default: () => {} },
-    autosave: { type: Boolean, default: true },
+    autosave: { type: Boolean, default: false },
     value: {
       type: String,
       default: '',

--- a/webapp/components/Editor/Editor.vue
+++ b/webapp/components/Editor/Editor.vue
@@ -113,7 +113,7 @@ export default {
       return extensions
     },
     autosaveContent() {
-      return this.autosave && this.$route ? AutoSave.load(this.$route.path) : ''
+      return this.autosave && this.$route ? AutoSave.lastSave(this.$route.path) : ''
     },
   },
   watch: {

--- a/webapp/components/Editor/defaultExtensions.js
+++ b/webapp/components/Editor/defaultExtensions.js
@@ -4,6 +4,7 @@ import Link from '~/components/Editor/nodes/Link.js'
 import Strike from '~/components/Editor/marks/Strike'
 import Italic from '~/components/Editor/marks/Italic'
 import Bold from '~/components/Editor/marks/Bold'
+import AutoSave from '~/components/Editor/plugins/autoSave'
 import EmbedQuery from '~/graphql/EmbedQuery.js'
 import {
   Heading,
@@ -18,8 +19,8 @@ import {
 } from 'tiptap-extensions'
 
 export default function defaultExtensions(component) {
-  const { placeholder, $t, $apollo } = component
-  return [
+  const { autosave, placeholder, $t, $apollo, $route } = component
+  const extensions = [
     new Heading(),
     new HardBreak(),
     new Blockquote(),
@@ -54,4 +55,10 @@ export default function defaultExtensions(component) {
       },
     }),
   ]
+
+  if (autosave && $route) {
+    extensions.push(new AutoSave({ $route }))
+  }
+
+  return extensions
 }

--- a/webapp/components/Editor/plugins/autoSave.js
+++ b/webapp/components/Editor/plugins/autoSave.js
@@ -23,6 +23,13 @@ export default class AutoSave extends Extension {
     if (this.route.path === '/post/create') {
       return `draft:post:${this._postId}`
     }
+
+    const commentMatch = this.route.path.match(/^\/post\/([0-9a-f-]*)\/[\w-]*$/)
+    if (commentMatch) {
+      const key = `draft:${commentMatch[1]}`
+      return key
+    }
+
     return null
   }
 
@@ -38,16 +45,6 @@ export default class AutoSave extends Extension {
             )
           }
           return tr
-        },
-        state: {
-          init() {
-            return {
-              saveNextUpdate: false,
-            }
-          },
-          apply(_, prev) {
-            return { ...prev }
-          },
         },
       }),
     ]

--- a/webapp/components/Editor/plugins/autoSave.js
+++ b/webapp/components/Editor/plugins/autoSave.js
@@ -7,14 +7,14 @@ export default class AutoSave extends Extension {
     super()
 
     this.route = $route
-    const { id = hash(Date.now().toString(), 0xb0b).toString(16), editorType } = AutoSave.for(
+    const { id = hash(Date.now().toString(), 0xb0b).toString(16), editorType } = AutoSave.fromPath(
       this.route.path,
     )
     this.id = id
     this.editorType = editorType
   }
 
-  static for(path) {
+  static fromPath(path) {
     if (path === '/post/create') {
       return { editorType: 'post' }
     }
@@ -24,7 +24,7 @@ export default class AutoSave extends Extension {
       return { editorType: 'comment', id: hash(commentMatch[1], 0xb0b).toString(16) }
     }
 
-    return null
+    return {}
   }
 
   static toHTML(content, schema) {
@@ -35,7 +35,7 @@ export default class AutoSave extends Extension {
   }
 
   static load(path) {
-    const { id = localStorage.getItem('autosave:post:last'), editorType } = AutoSave.for(path)
+    const { id = localStorage.getItem('autosave:post:last'), editorType } = AutoSave.fromPath(path)
     const key = AutoSave.getStorageKey(id, editorType)
     return key ? localStorage[key] : null
   }

--- a/webapp/components/Editor/plugins/autoSave.js
+++ b/webapp/components/Editor/plugins/autoSave.js
@@ -7,14 +7,16 @@ export default class AutoSave extends Extension {
     super()
 
     this.route = $route
-    const { id, editorType } = AutoSave.for(this.route.path)
+    const { id = hash(Date.now().toString(), 0xb0b).toString(16), editorType } = AutoSave.for(
+      this.route.path,
+    )
     this.id = id
     this.editorType = editorType
   }
 
   static for(path) {
     if (path === '/post/create') {
-      return { editorType: 'post', id: hash(Date.now().toString(), 0xb0b).toString(16) }
+      return { editorType: 'post' }
     }
 
     const commentMatch = path.match(/^\/post\/([0-9a-f-]*)\/[\w-]*$/)
@@ -33,7 +35,7 @@ export default class AutoSave extends Extension {
   }
 
   static load(path) {
-    const { id, editorType } = AutoSave.for(path)
+    const { id = localStorage.getItem('autosave:post:last'), editorType } = AutoSave.for(path)
     const key = AutoSave.getStorageKey(id, editorType)
     return key ? localStorage[key] : null
   }

--- a/webapp/components/Editor/plugins/autoSave.js
+++ b/webapp/components/Editor/plugins/autoSave.js
@@ -1,0 +1,55 @@
+import { Extension, Plugin, PluginKey } from 'tiptap'
+import { DOMSerializer } from 'prosemirror-model'
+
+export default class AutoSave extends Extension {
+  constructor({ $route }) {
+    super()
+    this.route = $route
+    this._postId = 'randomIdForPosts'
+  }
+
+  static toHTML(content, schema) {
+    const container = document.createElement('div')
+    const fragment = DOMSerializer.fromSchema(schema).serializeFragment(content)
+    container.appendChild(fragment)
+    return container.innerHTML
+  }
+
+  get name() {
+    return 'auto_save'
+  }
+
+  get storageKey() {
+    if (this.route.path === '/post/create') {
+      return `draft:post:${this._postId}`
+    }
+    return null
+  }
+
+  get plugins() {
+    return [
+      new Plugin({
+        key: new PluginKey('auto_save'),
+        filterTransaction: (tr, editorState) => {
+          if (tr.docChanged) {
+            localStorage.setItem(
+              this.storageKey,
+              AutoSave.toHTML(tr.doc.content, editorState.config.schema),
+            )
+          }
+          return tr
+        },
+        state: {
+          init() {
+            return {
+              saveNextUpdate: false,
+            }
+          },
+          apply(_, prev) {
+            return { ...prev }
+          },
+        },
+      }),
+    ]
+  }
+}

--- a/webapp/components/Editor/plugins/autoSave.js
+++ b/webapp/components/Editor/plugins/autoSave.js
@@ -7,9 +7,10 @@ export default class AutoSave extends Extension {
     super()
 
     this.route = $route
-    const { id = hash(Date.now().toString(), 0xb0b).toString(16), editorType } = AutoSave.fromPath(
-      this.route.path,
-    )
+    const {
+      id = hash(Date.now().toString(), 0xb0b).toString(16),
+      editorType = this.route.path,
+    } = AutoSave.fromPath(this.route.path)
     this.id = id
     this.editorType = editorType
   }
@@ -35,9 +36,13 @@ export default class AutoSave extends Extension {
   }
 
   static load(path) {
-    const { id = localStorage.getItem('autosave:post:last'), editorType } = AutoSave.fromPath(path)
-    const key = AutoSave.getStorageKey(id, editorType)
-    return key ? localStorage[key] : null
+    const { id, editorType = path } = AutoSave.fromPath(path)
+    const _id = localStorage.getItem(`autosave:${editorType}:last`)
+    if (!_id) {
+      return null
+    }
+    const key = AutoSave.getStorageKey(_id, editorType)
+    return localStorage[key]
   }
 
   static getStorageKey(id, editorType) {
@@ -62,9 +67,7 @@ export default class AutoSave extends Extension {
               this.storageKey,
               AutoSave.toHTML(tr.doc.content, editorState.config.schema),
             )
-            if (this.editorType === 'post') {
-              localStorage.setItem('autosave:post:last', this.id)
-            }
+            localStorage.setItem(`autosave:${this.editorType}:last`, this.id)
           }
           return tr
         },

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -94,6 +94,7 @@
     "vue-sweetalert-icons": "~4.2.0",
     "vuex-i18n": "~1.13.1",
     "xregexp": "^4.3.0",
+    "xxhashjs": "^0.2.2",
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {

--- a/webapp/storybook/helpers.js
+++ b/webapp/storybook/helpers.js
@@ -67,7 +67,7 @@ const helpers = {
         </base-card>
       `,
     }
-  }
+  },
 }
 
 export default helpers

--- a/webapp/storybook/helpers.js
+++ b/webapp/storybook/helpers.js
@@ -57,6 +57,17 @@ const helpers = {
       </layout>`,
     }
   },
+  wrapInCard(storyFn) {
+    const ctx = storyFn()
+    return {
+      components: { ctx },
+      template: `
+        <base-card style="width: 50%; min-width: 500px; margin: 0 auto;">
+            <ctx />
+        </base-card>
+      `,
+    }
+  }
 }
 
 export default helpers

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -17450,7 +17450,7 @@ xtend@^4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
-xxhashjs@^0.2.1:
+xxhashjs@^0.2.1, xxhashjs@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/xxhashjs/-/xxhashjs-0.2.2.tgz#8a6251567621a1c46a5ae204da0249c7f8caa9d8"
   integrity sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==


### PR DESCRIPTION
## 🍰 Pullrequest
Adds ProseMirror plugin AutoSave

  - saves comments and posts, as they are typed
  - loads last autosave when creating a new post

### Issues
- implements #3252
- relates #3461

### Todo
UI elements for
- [ ] loading/picking autosave for /post/create

Setting for
- [ ] 'load last autosave'; bool