### PR TITLE
fix: editor list styles [3492]

### DIFF
--- a/webapp/assets/_new/styles/tokens.scss
+++ b/webapp/assets/_new/styles/tokens.scss
@@ -191,10 +191,10 @@ $font-weight-bold: 600;
  * @presenter LineHeight
  */
 
-$line-height-large: 1.5;
-$line-height-base: 1.3;
-$line-height-small: 1.1;
-$line-height-smaller: 1.0;
+$line-height-large: 1.5rem;
+$line-height-base: 1.3rem;
+$line-height-small: 1.1rem;
+$line-height-smaller: 1.0rem;
 
 /**
  * @tokens Letter Spacing
@@ -352,3 +352,8 @@ $media-query-small: (min-width: 600px);
 $media-query-medium: (min-width: 768px);
 $media-query-large: (min-width: 1024px);
 $media-query-x-large: (min-width: 1200px);
+
+/** 
+ * @tokens Background Images
+ */
+$background-image-logo: url('/icon.png');

--- a/webapp/components/Editor/Editor.vue
+++ b/webapp/components/Editor/Editor.vue
@@ -327,5 +327,28 @@ li > p {
   p {
     margin: 0 0 $space-x-small;
   }
+
+  ol {
+    counter-reset: item;
+    padding-left: $space-x-small;
+
+    li {
+      display: block;
+
+      &:before {
+        content: counters(item, '.') '.';
+        counter-increment: item;
+        margin-right: $space-x-small;
+      }
+
+      > p {
+        display: inline-block;
+      }
+    }
+  }
+
+  > ol {
+    padding-left: $space-small;
+  }
 }
 </style>

--- a/webapp/components/Editor/Editor.vue
+++ b/webapp/components/Editor/Editor.vue
@@ -328,7 +328,28 @@ li > p {
     margin: 0 0 $space-x-small;
   }
 
+  ul {
+    li {
+      display: block;
+
+      &:before {
+        content: '';
+        background-image: $background-image-logo;
+        background-position: center;
+        background-repeat: no-repeat;
+        background-size: $line-height-small;
+        padding: $space-none $space-x-small;
+        margin-right: $space-x-small;
+      }
+
+      > p {
+        display: inline-block;
+      }
+    }
+  }
+
   ol {
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Lists_and_Counters/Using_CSS_counters
     counter-reset: item;
     padding-left: $space-x-small;
 
@@ -347,7 +368,8 @@ li > p {
     }
   }
 
-  > ol {
+  > ol,
+  > ul {
     padding-left: $space-small;
   }
 }


### PR DESCRIPTION
## 🍰 Pullrequest
Adds decorators back to `<ul>`, `<ol>` Elements, inside Editor.
Using the logo as bullet is maybe a bit over the top :relaxed: 

![list_decorators](https://user-images.githubusercontent.com/3411649/79811337-e2efcc80-8375-11ea-83a1-d92b7e0df074.png)


### Issues
- fixes #3492
