### PR TITLE
fixed css so follow button isn't blocked by adblock

### DIFF
--- a/webapp/components/FollowButton.vue
+++ b/webapp/components/FollowButton.vue
@@ -1,6 +1,6 @@
 <template>
   <base-button
-    class="follow-button"
+    class="track-button"
     :disabled="disabled || !followId"
     :loading="loading"
     :icon="icon"
@@ -85,7 +85,7 @@ export default {
 </script>
 
 <style lang="scss">
-.follow-button {
+.track-button {
   display: block;
   width: 100%;
 }


### PR DESCRIPTION
I change the name of the css classes that held the follow button on a user's profile so that it no longer is blocked by uBlock. 
