### PR TITLE
fix: 🍰 Checkboxes Not Missing Anymore On Delete User Account Page

### DIFF
--- a/backend/src/schema/resolvers/statistics.spec.js
+++ b/backend/src/schema/resolvers/statistics.spec.js
@@ -8,7 +8,7 @@ let query, authenticatedUser
 const instance = getNeode()
 const driver = getDriver()
 
-const statisticsQuery = gql `
+const statisticsQuery = gql`
   query {
     statistics {
       countUsers
@@ -22,118 +22,118 @@ const statisticsQuery = gql `
   }
 `
 beforeAll(() => {
-    authenticatedUser = undefined
-    const { server } = createServer({
-        context: () => {
-            return {
-                driver,
-                neode: instance,
-                user: authenticatedUser,
-            }
-        },
-    })
-    query = createTestClient(server).query
+  authenticatedUser = undefined
+  const { server } = createServer({
+    context: () => {
+      return {
+        driver,
+        neode: instance,
+        user: authenticatedUser,
+      }
+    },
+  })
+  query = createTestClient(server).query
 })
 
-afterEach(async() => {
-    await cleanDatabase()
+afterEach(async () => {
+  await cleanDatabase()
 })
 
 describe('statistics', () => {
-    describe('countUsers', () => {
-        beforeEach(async() => {
-            await Promise.all(
-                [...Array(6).keys()].map(() => {
-                    return Factory.build('user')
-                }),
-            )
-        })
-
-        it('returns the count of all users', async() => {
-            await expect(query({ query: statisticsQuery })).resolves.toMatchObject({
-                data: { statistics: { countUsers: 6 } },
-                errors: undefined,
-            })
-        })
+  describe('countUsers', () => {
+    beforeEach(async () => {
+      await Promise.all(
+        [...Array(6).keys()].map(() => {
+          return Factory.build('user')
+        }),
+      )
     })
 
-    describe('countPosts', () => {
-        beforeEach(async() => {
-            await Promise.all(
-                [...Array(3).keys()].map(() => {
-                    return Factory.build('post')
-                }),
-            )
-        })
+    it('returns the count of all users', async () => {
+      await expect(query({ query: statisticsQuery })).resolves.toMatchObject({
+        data: { statistics: { countUsers: 6 } },
+        errors: undefined,
+      })
+    })
+  })
 
-        it('returns the count of all posts', async() => {
-            await expect(query({ query: statisticsQuery })).resolves.toMatchObject({
-                data: { statistics: { countPosts: 3 } },
-                errors: undefined,
-            })
-        })
+  describe('countPosts', () => {
+    beforeEach(async () => {
+      await Promise.all(
+        [...Array(3).keys()].map(() => {
+          return Factory.build('post')
+        }),
+      )
     })
 
-    describe('countComments', () => {
-        beforeEach(async() => {
-            await Promise.all(
-                [...Array(2).keys()].map(() => {
-                    return Factory.build('comment')
-                }),
-            )
-        })
+    it('returns the count of all posts', async () => {
+      await expect(query({ query: statisticsQuery })).resolves.toMatchObject({
+        data: { statistics: { countPosts: 3 } },
+        errors: undefined,
+      })
+    })
+  })
 
-        it('returns the count of all comments', async() => {
-            await expect(query({ query: statisticsQuery })).resolves.toMatchObject({
-                data: { statistics: { countComments: 2 } },
-                errors: undefined,
-            })
-        })
+  describe('countComments', () => {
+    beforeEach(async () => {
+      await Promise.all(
+        [...Array(2).keys()].map(() => {
+          return Factory.build('comment')
+        }),
+      )
     })
 
-    describe('countFollows', () => {
-        let users
-        beforeEach(async() => {
-            users = await Promise.all(
-                [...Array(2).keys()].map(() => {
-                    return Factory.build('user')
-                }),
-            )
-            await users[0].relateTo(users[1], 'following')
-        })
+    it('returns the count of all comments', async () => {
+      await expect(query({ query: statisticsQuery })).resolves.toMatchObject({
+        data: { statistics: { countComments: 2 } },
+        errors: undefined,
+      })
+    })
+  })
 
-        it('returns the count of all follows', async() => {
-            await expect(query({ query: statisticsQuery })).resolves.toMatchObject({
-                data: { statistics: { countFollows: 1 } },
-                errors: undefined,
-            })
-        })
+  describe('countFollows', () => {
+    let users
+    beforeEach(async () => {
+      users = await Promise.all(
+        [...Array(2).keys()].map(() => {
+          return Factory.build('user')
+        }),
+      )
+      await users[0].relateTo(users[1], 'following')
     })
 
-    describe('countShouts', () => {
-        let users, posts
-        beforeEach(async() => {
-            users = await Promise.all(
-                [...Array(2).keys()].map(() => {
-                    return Factory.build('user')
-                }),
-            )
-            posts = await Promise.all(
-                [...Array(3).keys()].map(() => {
-                    return Factory.build('post')
-                }),
-            )
-            await Promise.all([
-                users[0].relateTo(posts[1], 'shouted'),
-                users[1].relateTo(posts[0], 'shouted'),
-            ])
-        })
-
-        it('returns the count of all shouts', async() => {
-            await expect(query({ query: statisticsQuery })).resolves.toMatchObject({
-                data: { statistics: { countShouts: 2 } },
-                errors: undefined,
-            })
-        })
+    it('returns the count of all follows', async () => {
+      await expect(query({ query: statisticsQuery })).resolves.toMatchObject({
+        data: { statistics: { countFollows: 1 } },
+        errors: undefined,
+      })
     })
+  })
+
+  describe('countShouts', () => {
+    let users, posts
+    beforeEach(async () => {
+      users = await Promise.all(
+        [...Array(2).keys()].map(() => {
+          return Factory.build('user')
+        }),
+      )
+      posts = await Promise.all(
+        [...Array(3).keys()].map(() => {
+          return Factory.build('post')
+        }),
+      )
+      await Promise.all([
+        users[0].relateTo(posts[1], 'shouted'),
+        users[1].relateTo(posts[0], 'shouted'),
+      ])
+    })
+
+    it('returns the count of all shouts', async () => {
+      await expect(query({ query: statisticsQuery })).resolves.toMatchObject({
+        data: { statistics: { countShouts: 2 } },
+        errors: undefined,
+      })
+    })
+  })
 })

--- a/backend/src/schema/resolvers/statistics.spec.js
+++ b/backend/src/schema/resolvers/statistics.spec.js
@@ -8,7 +8,7 @@ let query, authenticatedUser
 const instance = getNeode()
 const driver = getDriver()
 
-const statisticsQuery = gql`
+const statisticsQuery = gql `
   query {
     statistics {
       countUsers
@@ -22,118 +22,118 @@ const statisticsQuery = gql`
   }
 `
 beforeAll(() => {
-  authenticatedUser = undefined
-  const { server } = createServer({
-    context: () => {
-      return {
-        driver,
-        neode: instance,
-        user: authenticatedUser,
-      }
-    },
-  })
-  query = createTestClient(server).query
+    authenticatedUser = undefined
+    const { server } = createServer({
+        context: () => {
+            return {
+                driver,
+                neode: instance,
+                user: authenticatedUser,
+            }
+        },
+    })
+    query = createTestClient(server).query
 })
 
-afterEach(async () => {
-  await cleanDatabase()
+afterEach(async() => {
+    await cleanDatabase()
 })
 
 describe('statistics', () => {
-  describe('countUsers', () => {
-    beforeEach(async () => {
-      await Promise.all(
-        [...Array(6).keys()].map(() => {
-          return Factory.build('user')
-        }),
-      )
+    describe('countUsers', () => {
+        beforeEach(async() => {
+            await Promise.all(
+                [...Array(6).keys()].map(() => {
+                    return Factory.build('user')
+                }),
+            )
+        })
+
+        it('returns the count of all users', async() => {
+            await expect(query({ query: statisticsQuery })).resolves.toMatchObject({
+                data: { statistics: { countUsers: 6 } },
+                errors: undefined,
+            })
+        })
     })
 
-    it('returns the count of all users', async () => {
-      await expect(query({ query: statisticsQuery })).resolves.toMatchObject({
-        data: { statistics: { countUsers: 6 } },
-        errors: undefined,
-      })
-    })
-  })
+    describe('countPosts', () => {
+        beforeEach(async() => {
+            await Promise.all(
+                [...Array(3).keys()].map(() => {
+                    return Factory.build('post')
+                }),
+            )
+        })
 
-  describe('countPosts', () => {
-    beforeEach(async () => {
-      await Promise.all(
-        [...Array(3).keys()].map(() => {
-          return Factory.build('post')
-        }),
-      )
-    })
-
-    it('returns the count of all posts', async () => {
-      await expect(query({ query: statisticsQuery })).resolves.toMatchObject({
-        data: { statistics: { countPosts: 3 } },
-        errors: undefined,
-      })
-    })
-  })
-
-  describe('countComments', () => {
-    beforeEach(async () => {
-      await Promise.all(
-        [...Array(2).keys()].map(() => {
-          return Factory.build('comment')
-        }),
-      )
+        it('returns the count of all posts', async() => {
+            await expect(query({ query: statisticsQuery })).resolves.toMatchObject({
+                data: { statistics: { countPosts: 3 } },
+                errors: undefined,
+            })
+        })
     })
 
-    it('returns the count of all comments', async () => {
-      await expect(query({ query: statisticsQuery })).resolves.toMatchObject({
-        data: { statistics: { countComments: 2 } },
-        errors: undefined,
-      })
-    })
-  })
+    describe('countComments', () => {
+        beforeEach(async() => {
+            await Promise.all(
+                [...Array(2).keys()].map(() => {
+                    return Factory.build('comment')
+                }),
+            )
+        })
 
-  describe('countFollows', () => {
-    let users
-    beforeEach(async () => {
-      users = await Promise.all(
-        [...Array(2).keys()].map(() => {
-          return Factory.build('user')
-        }),
-      )
-      await users[0].relateTo(users[1], 'following')
+        it('returns the count of all comments', async() => {
+            await expect(query({ query: statisticsQuery })).resolves.toMatchObject({
+                data: { statistics: { countComments: 2 } },
+                errors: undefined,
+            })
+        })
     })
 
-    it('returns the count of all follows', async () => {
-      await expect(query({ query: statisticsQuery })).resolves.toMatchObject({
-        data: { statistics: { countFollows: 1 } },
-        errors: undefined,
-      })
-    })
-  })
+    describe('countFollows', () => {
+        let users
+        beforeEach(async() => {
+            users = await Promise.all(
+                [...Array(2).keys()].map(() => {
+                    return Factory.build('user')
+                }),
+            )
+            await users[0].relateTo(users[1], 'following')
+        })
 
-  describe('countShouts', () => {
-    let users, posts
-    beforeEach(async () => {
-      users = await Promise.all(
-        [...Array(2).keys()].map(() => {
-          return Factory.build('user')
-        }),
-      )
-      posts = await Promise.all(
-        [...Array(3).keys()].map(() => {
-          return Factory.build('post')
-        }),
-      )
-      await Promise.all([
-        users[0].relateTo(posts[1], 'shouted'),
-        users[1].relateTo(posts[0], 'shouted'),
-      ])
+        it('returns the count of all follows', async() => {
+            await expect(query({ query: statisticsQuery })).resolves.toMatchObject({
+                data: { statistics: { countFollows: 1 } },
+                errors: undefined,
+            })
+        })
     })
 
-    it('returns the count of all shouts', async () => {
-      await expect(query({ query: statisticsQuery })).resolves.toMatchObject({
-        data: { statistics: { countShouts: 2 } },
-        errors: undefined,
-      })
+    describe('countShouts', () => {
+        let users, posts
+        beforeEach(async() => {
+            users = await Promise.all(
+                [...Array(2).keys()].map(() => {
+                    return Factory.build('user')
+                }),
+            )
+            posts = await Promise.all(
+                [...Array(3).keys()].map(() => {
+                    return Factory.build('post')
+                }),
+            )
+            await Promise.all([
+                users[0].relateTo(posts[1], 'shouted'),
+                users[1].relateTo(posts[0], 'shouted'),
+            ])
+        })
+
+        it('returns the count of all shouts', async() => {
+            await expect(query({ query: statisticsQuery })).resolves.toMatchObject({
+                data: { statistics: { countShouts: 2 } },
+                errors: undefined,
+            })
+        })
     })
-  })
 })

--- a/backend/src/schema/resolvers/users.spec.js
+++ b/backend/src/schema/resolvers/users.spec.js
@@ -18,7 +18,7 @@ let variables
 const driver = getDriver()
 const neode = getNeode()
 
-const deleteUserMutation = gql `
+const deleteUserMutation = gql`
   mutation($id: ID!, $resource: [Deletable]) {
     DeleteUser(id: $id, resource: $resource) {
       id
@@ -48,517 +48,560 @@ const deleteUserMutation = gql `
 `
 
 beforeAll(() => {
-    const { server } = createServer({
-        context: () => {
-            return {
-                driver,
-                neode,
-                user: authenticatedUser,
-            }
-        },
-    })
-    query = createTestClient(server).query
-    mutate = createTestClient(server).mutate
+  const { server } = createServer({
+    context: () => {
+      return {
+        driver,
+        neode,
+        user: authenticatedUser,
+      }
+    },
+  })
+  query = createTestClient(server).query
+  mutate = createTestClient(server).mutate
 })
 
-beforeEach(async() => {
-    await cleanDatabase()
+beforeEach(async () => {
+  await cleanDatabase()
 })
-
 
 describe('User', () => {
-    describe('query by email address', () => {
-        beforeEach(async() => {
-            await Factory.build('user', { name: 'Johnny' }, { email: 'any-email-address@example.org' })
-        })
-
-        const userQuery = gql `query($email: String) { User(email: $email) {  name      }    }`
-        const variables = { email: 'any-email-address@example.org' }
-
-        it('is forbidden', async() => {
-            await expect(query({ query: userQuery, variables })).resolves.toMatchObject({
-                errors: [{ message: 'Not Authorised!' }],
-            })
-        })
-
-        describe('as admin', () => {
-            beforeEach(async() => {
-                const admin = await Factory.build(
-                    'user', {
-                        role: 'admin',
-                    }, {
-                        email: 'admin@example.org',
-                        password: '1234',
-                    },
-                )
-                authenticatedUser = await admin.toJson()
-            })
-
-            it('is permitted', async() => {
-                await expect(query({ query: userQuery, variables })).resolves.toMatchObject({
-                    data: { User: [{ name: 'Johnny' }] },
-                    errors: undefined,
-                })
-            })
-
-            it('non-existing email address, issue #2294', async() => {
-                // see: https://github.com/Human-Connection/Human-Connection/issues/2294
-                await expect(
-                    query({
-                        query: userQuery,
-                        variables: {
-                            email: 'this-email-does-not-exist@example.org',
-                        },
-                    }),
-                ).resolves.toMatchObject({
-                    data: { User: [] },
-                    errors: undefined,
-                })
-            })
-        })
+  describe('query by email address', () => {
+    beforeEach(async () => {
+      await Factory.build('user', { name: 'Johnny' }, { email: 'any-email-address@example.org' })
     })
-})
 
-
-
-describe('UpdateUser', () => {
-    let variables
-
-    beforeEach(async() => {
-        variables = {
-            id: 'u47',
-            name: 'John Doughnut',
+    const userQuery = gql`
+      query($email: String) {
+        User(email: $email) {
+          name
         }
-    })
+      }
+    `
+    const variables = { email: 'any-email-address@example.org' }
 
-    const updateUserMutation = gql `
-  mutation(
-    $id: ID!
-    $name: String
-    $termsAndConditionsAgreedVersion: String
-    $locationName: String
-  ) {
-    UpdateUser(
-      id: $id
-      name: $name
-      termsAndConditionsAgreedVersion: $termsAndConditionsAgreedVersion
-      locationName: $locationName
-    ) {
-      id
-      name
-      termsAndConditionsAgreedVersion
-      termsAndConditionsAgreedAt
-      locationName
-    }
-  }
-`
-    beforeEach(async() => {
-        user = await Factory.build(
-            'user', {
-                id: 'u47',
-                name: 'John Doe',
-                termsAndConditionsAgreedVersion: null,
-                termsAndConditionsAgreedAt: null,
-                allowEmbedIframes: false,
-            }, {
-                email: 'user@example.org',
-            },
-        )
-    })
-
-    describe('as another user', () => {
-        beforeEach(async() => {
-            const someoneElse = await Factory.build(
-                'user', {
-                    name: 'James Doe',
-                }, {
-                    email: 'someone-else@example.org',
-                },
-            )
-
-            authenticatedUser = await someoneElse.toJson()
-        })
-
-        it('is not allowed to change other user accounts', async() => {
-            const { errors } = await mutate({ mutation: updateUserMutation, variables })
-            expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-        })
-    })
-
-    describe('as the same user', () => {
-        beforeEach(async() => {
-            authenticatedUser = await user.toJson()
-        })
-
-        it('updates the name', async() => {
-            const expected = {
-                data: {
-                    UpdateUser: {
-                        id: 'u47',
-                        name: 'John Doughnut',
-                    },
-                },
-                errors: undefined,
-            }
-            await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
-                expected,
-            )
-        })
-
-        describe('given a new agreed version of terms and conditions', () => {
-            beforeEach(async() => {
-                variables = {...variables, termsAndConditionsAgreedVersion: '0.0.2' }
-            })
-            it('update termsAndConditionsAgreedVersion', async() => {
-                const expected = {
-                    data: {
-                        UpdateUser: expect.objectContaining({
-                            termsAndConditionsAgreedVersion: '0.0.2',
-                            termsAndConditionsAgreedAt: expect.any(String),
-                        }),
-                    },
-                    errors: undefined,
-                }
-
-                await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
-                    expected,
-                )
-            })
-        })
-
-        describe('given any attribute other than termsAndConditionsAgreedVersion', () => {
-            beforeEach(async() => {
-                variables = {...variables, name: 'any name' }
-            })
-            it('update termsAndConditionsAgreedVersion', async() => {
-                const expected = {
-                    data: {
-                        UpdateUser: expect.objectContaining({
-                            termsAndConditionsAgreedVersion: null,
-                            termsAndConditionsAgreedAt: null,
-                        }),
-                    },
-                    errors: undefined,
-                }
-
-                await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
-                    expected,
-                )
-            })
-        })
-
-        it('rejects if version of terms and conditions has wrong format', async() => {
-            variables = {
-                ...variables,
-                termsAndConditionsAgreedVersion: 'invalid version format',
-            }
-            const { errors } = await mutate({ mutation: updateUserMutation, variables })
-            expect(errors[0]).toHaveProperty('message', 'Invalid version format!')
-        })
-
-        it('supports updating location', async() => {
-            variables = {...variables, locationName: 'Hamburg, New Jersey, United States of America' }
-            await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject({
-                data: { UpdateUser: { locationName: 'Hamburg, New Jersey, United States of America' } },
-                errors: undefined,
-            })
-        })
-    })
-})
-
-describe('Delete a user', () => {
-    beforeEach(async() => {
-        variables = { id: ' u343', resource: [] }
-
-        user = await Factory.build('user', {
-            name: 'My name should be deleted',
-            about: 'along with my about',
-            id: 'u343',
-        })
-    })
-
-    describe('as another user', () => {
-        beforeEach(async() => {
-
-            anotherUser = await Factory.build(
-                'user', {
-                    role: 'user',
-                }, {
-                    email: 'user@example.org',
-                    password: '1234',
-                },
-            )
-
-            authenticatedUser = await anotherUser.toJson()
-        })
-
-        it("an ordinary user has no authorization to delete another user's account", async() => {
-            const { errors } = await mutate({ mutation: deleteUserMutation, variables })
-            expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-        })
-    })
-
-    describe('as moderator', () => {
-        beforeEach(async() => {
-
-            moderator = await Factory.build(
-                'user', {
-                    role: 'moderator',
-                }, {
-                    email: 'moderator@example.org',
-                    password: '1234',
-                },
-            )
-
-            authenticatedUser = await moderator.toJson()
-        })
-
-        it('moderator is not allowed to delete other user accounts', async() => {
-            const { errors } = await mutate({ mutation: deleteUserMutation, variables })
-            expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-        })
+    it('is forbidden', async () => {
+      await expect(query({ query: userQuery, variables })).resolves.toMatchObject({
+        errors: [{ message: 'Not Authorised!' }],
+      })
     })
 
     describe('as admin', () => {
-        describe('authenticated as Admin', () => {
-            beforeEach(async() => {
-                admin = await Factory.build(
-                    'user', {
-                        role: 'admin',
-                    }, {
-                        email: 'admin@example.org',
-                        password: '1234',
-                    },
-                )
-                authenticatedUser = await admin.toJson()
-            })
+      beforeEach(async () => {
+        const admin = await Factory.build(
+          'user',
+          {
+            role: 'admin',
+          },
+          {
+            email: 'admin@example.org',
+            password: '1234',
+          },
+        )
+        authenticatedUser = await admin.toJson()
+      })
 
-            describe('deleting a user account', () => {
-                beforeEach(() => {
-                    variables = {...variables, id: 'u343' }
-                })
-
-                describe('given posts and comments', () => {
-                    beforeEach(async() => {
-                        await Factory.build('category', {
-                            id: 'cat9',
-                            name: 'Democracy & Politics',
-                            icon: 'university',
-                        })
-                        await Factory.build(
-                            'post', {
-                                id: 'p139',
-                                content: 'Post by user u343',
-                            }, {
-                                author: user,
-                                categoryIds,
-                            },
-                        )
-                        await Factory.build(
-                            'comment', {
-                                id: 'c155',
-                                content: 'Comment by user u343',
-                            }, {
-                                author: user,
-                            },
-                        )
-                        await Factory.build(
-                            'comment', {
-                                id: 'c156',
-                                content: "A comment by someone else on user u343's post",
-                            }, {
-                                postId: 'p139',
-                            },
-                        )
-                    })
-
-                    it("deletes account, but doesn't delete posts or comments by default", async() => {
-                        const expectedResponse = {
-                            data: {
-                                DeleteUser: {
-                                    id: 'u343',
-                                    name: 'UNAVAILABLE',
-                                    about: 'UNAVAILABLE',
-                                    deleted: true,
-                                    contributions: [{
-                                        id: 'p139',
-                                        content: 'Post by user u343',
-                                        contentExcerpt: 'Post by user u343',
-                                        deleted: false,
-                                        comments: [{
-                                            id: 'c156',
-                                            content: "A comment by someone else on user u343's post",
-                                            contentExcerpt: "A comment by someone else on user u343's post",
-                                            deleted: false,
-                                        }, ],
-                                    }, ],
-                                    comments: [{
-                                        id: 'c155',
-                                        content: 'Comment by user u343',
-                                        contentExcerpt: 'Comment by user u343',
-                                        deleted: false,
-                                    }, ],
-                                },
-                            },
-                            errors: undefined,
-                        }
-                        await expect(mutate({ mutation: deleteUserMutation, variables })).resolves.toMatchObject(
-                            expectedResponse,
-                        )
-                    })
-
-                    describe('deletion of all post requested', () => {
-                        beforeEach(() => {
-                            variables = {...variables, resource: ['Post'] }
-                        })
-
-                        it('on request', async() => {
-                            const expectedResponse = {
-                                data: {
-                                    DeleteUser: {
-                                        id: 'u343',
-                                        name: 'UNAVAILABLE',
-                                        about: 'UNAVAILABLE',
-                                        deleted: true,
-                                        contributions: [{
-                                            id: 'p139',
-                                            content: 'UNAVAILABLE',
-                                            contentExcerpt: 'UNAVAILABLE',
-                                            deleted: true,
-                                            comments: [{
-                                                id: 'c156',
-                                                content: 'UNAVAILABLE',
-                                                contentExcerpt: 'UNAVAILABLE',
-                                                deleted: true,
-                                            }, ],
-                                        }, ],
-                                        comments: [{
-                                            id: 'c155',
-                                            content: 'Comment by user u343',
-                                            contentExcerpt: 'Comment by user u343',
-                                            deleted: false,
-                                        }, ],
-                                    },
-                                },
-                                errors: undefined,
-                            }
-                            await expect(
-                                mutate({ mutation: deleteUserMutation, variables }),
-                            ).resolves.toMatchObject(expectedResponse)
-                        })
-
-                        it('deletes user avatar and post hero images', async() => {
-                            await expect(neode.all('Image')).resolves.toHaveLength(22)
-                            await mutate({ mutation: deleteUserMutation, variables })
-                            await expect(neode.all('Image')).resolves.toHaveLength(20)
-                        })
-                    })
-
-                    describe('deletion of all comments requested', () => {
-                        beforeEach(() => {
-                            variables = {...variables, resource: ['Comment'] }
-                        })
-
-                        it('marks comments as deleted', async() => {
-                            const expectedResponse = {
-                                data: {
-                                    DeleteUser: {
-                                        id: 'u343',
-                                        name: 'UNAVAILABLE',
-                                        about: 'UNAVAILABLE',
-                                        deleted: true,
-                                        contributions: [{
-                                            id: 'p139',
-                                            content: 'Post by user u343',
-                                            contentExcerpt: 'Post by user u343',
-                                            deleted: false,
-                                            comments: [{
-                                                id: 'c156',
-                                                content: "A comment by someone else on user u343's post",
-                                                contentExcerpt: "A comment by someone else on user u343's post",
-                                                deleted: false,
-                                            }, ],
-                                        }, ],
-                                        comments: [{
-                                            id: 'c155',
-                                            content: 'UNAVAILABLE',
-                                            contentExcerpt: 'UNAVAILABLE',
-                                            deleted: true,
-                                        }, ],
-                                    },
-                                },
-                                errors: undefined,
-                            }
-                            await expect(
-                                mutate({ mutation: deleteUserMutation, variables }),
-                            ).resolves.toMatchObject(expectedResponse)
-                        })
-                    })
-
-                    describe('deletion of all posts and comments requested', () => {
-                        beforeEach(() => {
-                            variables = {...variables, resource: ['Comment', 'Post'] }
-                        })
-
-                        it('marks posts and comments as deleted', async() => {
-                            const expectedResponse = {
-                                data: {
-                                    DeleteUser: {
-                                        id: 'u343',
-                                        name: 'UNAVAILABLE',
-                                        about: 'UNAVAILABLE',
-                                        deleted: true,
-                                        contributions: [{
-                                            id: 'p139',
-                                            content: 'UNAVAILABLE',
-                                            contentExcerpt: 'UNAVAILABLE',
-                                            deleted: true,
-                                            comments: [{
-                                                id: 'c156',
-                                                content: 'UNAVAILABLE',
-                                                contentExcerpt: 'UNAVAILABLE',
-                                                deleted: true,
-                                            }, ],
-                                        }, ],
-                                        comments: [{
-                                            id: 'c155',
-                                            content: 'UNAVAILABLE',
-                                            contentExcerpt: 'UNAVAILABLE',
-                                            deleted: true,
-                                        }, ],
-                                    },
-                                },
-                                errors: undefined,
-                            }
-                            await expect(
-                                mutate({ mutation: deleteUserMutation, variables }),
-                            ).resolves.toMatchObject(expectedResponse)
-                        })
-                    })
-                })
-
-                describe('connected `EmailAddress` nodes', () => {
-                    it('will be removed completely', async() => {
-                        await expect(neode.all('EmailAddress')).resolves.toHaveLength(2)
-                        await mutate({ mutation: deleteUserMutation, variables })
-
-                        await expect(neode.all('EmailAddress')).resolves.toHaveLength(1)
-                    })
-                })
-
-                describe('connected `SocialMedia` nodes', () => {
-                    beforeEach(async() => {
-                        const socialMedia = await Factory.build('socialMedia')
-                        await socialMedia.relateTo(user, 'ownedBy')
-                    })
-
-                    it('will be removed completely', async() => {
-                        await expect(neode.all('SocialMedia')).resolves.toHaveLength(1)
-                        await mutate({ mutation: deleteUserMutation, variables })
-                        await expect(neode.all('SocialMedia')).resolves.toHaveLength(0)
-                    })
-                })
-            })
+      it('is permitted', async () => {
+        await expect(query({ query: userQuery, variables })).resolves.toMatchObject({
+          data: { User: [{ name: 'Johnny' }] },
+          errors: undefined,
         })
+      })
+
+      it('non-existing email address, issue #2294', async () => {
+        // see: https://github.com/Human-Connection/Human-Connection/issues/2294
+        await expect(
+          query({
+            query: userQuery,
+            variables: {
+              email: 'this-email-does-not-exist@example.org',
+            },
+          }),
+        ).resolves.toMatchObject({
+          data: { User: [] },
+          errors: undefined,
+        })
+      })
     })
+  })
+})
+
+describe('UpdateUser', () => {
+  let variables
+
+  beforeEach(async () => {
+    variables = {
+      id: 'u47',
+      name: 'John Doughnut',
+    }
+  })
+
+  const updateUserMutation = gql`
+    mutation(
+      $id: ID!
+      $name: String
+      $termsAndConditionsAgreedVersion: String
+      $locationName: String
+    ) {
+      UpdateUser(
+        id: $id
+        name: $name
+        termsAndConditionsAgreedVersion: $termsAndConditionsAgreedVersion
+        locationName: $locationName
+      ) {
+        id
+        name
+        termsAndConditionsAgreedVersion
+        termsAndConditionsAgreedAt
+        locationName
+      }
+    }
+  `
+  beforeEach(async () => {
+    user = await Factory.build(
+      'user',
+      {
+        id: 'u47',
+        name: 'John Doe',
+        termsAndConditionsAgreedVersion: null,
+        termsAndConditionsAgreedAt: null,
+        allowEmbedIframes: false,
+      },
+      {
+        email: 'user@example.org',
+      },
+    )
+  })
+
+  describe('as another user', () => {
+    beforeEach(async () => {
+      const someoneElse = await Factory.build(
+        'user',
+        {
+          name: 'James Doe',
+        },
+        {
+          email: 'someone-else@example.org',
+        },
+      )
+
+      authenticatedUser = await someoneElse.toJson()
+    })
+
+    it('is not allowed to change other user accounts', async () => {
+      const { errors } = await mutate({ mutation: updateUserMutation, variables })
+      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+    })
+  })
+
+  describe('as the same user', () => {
+    beforeEach(async () => {
+      authenticatedUser = await user.toJson()
+    })
+
+    it('updates the name', async () => {
+      const expected = {
+        data: {
+          UpdateUser: {
+            id: 'u47',
+            name: 'John Doughnut',
+          },
+        },
+        errors: undefined,
+      }
+      await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
+        expected,
+      )
+    })
+
+    describe('given a new agreed version of terms and conditions', () => {
+      beforeEach(async () => {
+        variables = { ...variables, termsAndConditionsAgreedVersion: '0.0.2' }
+      })
+      it('update termsAndConditionsAgreedVersion', async () => {
+        const expected = {
+          data: {
+            UpdateUser: expect.objectContaining({
+              termsAndConditionsAgreedVersion: '0.0.2',
+              termsAndConditionsAgreedAt: expect.any(String),
+            }),
+          },
+          errors: undefined,
+        }
+
+        await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
+          expected,
+        )
+      })
+    })
+
+    describe('given any attribute other than termsAndConditionsAgreedVersion', () => {
+      beforeEach(async () => {
+        variables = { ...variables, name: 'any name' }
+      })
+      it('update termsAndConditionsAgreedVersion', async () => {
+        const expected = {
+          data: {
+            UpdateUser: expect.objectContaining({
+              termsAndConditionsAgreedVersion: null,
+              termsAndConditionsAgreedAt: null,
+            }),
+          },
+          errors: undefined,
+        }
+
+        await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
+          expected,
+        )
+      })
+    })
+
+    it('rejects if version of terms and conditions has wrong format', async () => {
+      variables = {
+        ...variables,
+        termsAndConditionsAgreedVersion: 'invalid version format',
+      }
+      const { errors } = await mutate({ mutation: updateUserMutation, variables })
+      expect(errors[0]).toHaveProperty('message', 'Invalid version format!')
+    })
+
+    it('supports updating location', async () => {
+      variables = { ...variables, locationName: 'Hamburg, New Jersey, United States of America' }
+      await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject({
+        data: { UpdateUser: { locationName: 'Hamburg, New Jersey, United States of America' } },
+        errors: undefined,
+      })
+    })
+  })
+})
+
+describe('Delete a user', () => {
+  beforeEach(async () => {
+    variables = { id: ' u343', resource: [] }
+
+    user = await Factory.build('user', {
+      name: 'My name should be deleted',
+      about: 'along with my about',
+      id: 'u343',
+    })
+  })
+
+  describe('as another user', () => {
+    beforeEach(async () => {
+      anotherUser = await Factory.build(
+        'user',
+        {
+          role: 'user',
+        },
+        {
+          email: 'user@example.org',
+          password: '1234',
+        },
+      )
+
+      authenticatedUser = await anotherUser.toJson()
+    })
+
+    it("an ordinary user has no authorization to delete another user's account", async () => {
+      const { errors } = await mutate({ mutation: deleteUserMutation, variables })
+      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+    })
+  })
+
+  describe('as moderator', () => {
+    beforeEach(async () => {
+      moderator = await Factory.build(
+        'user',
+        {
+          role: 'moderator',
+        },
+        {
+          email: 'moderator@example.org',
+          password: '1234',
+        },
+      )
+
+      authenticatedUser = await moderator.toJson()
+    })
+
+    it('moderator is not allowed to delete other user accounts', async () => {
+      const { errors } = await mutate({ mutation: deleteUserMutation, variables })
+      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+    })
+  })
+
+  describe('as admin', () => {
+    describe('authenticated as Admin', () => {
+      beforeEach(async () => {
+        admin = await Factory.build(
+          'user',
+          {
+            role: 'admin',
+          },
+          {
+            email: 'admin@example.org',
+            password: '1234',
+          },
+        )
+        authenticatedUser = await admin.toJson()
+      })
+
+      describe('deleting a user account', () => {
+        beforeEach(() => {
+          variables = { ...variables, id: 'u343' }
+        })
+
+        describe('given posts and comments', () => {
+          beforeEach(async () => {
+            await Factory.build('category', {
+              id: 'cat9',
+              name: 'Democracy & Politics',
+              icon: 'university',
+            })
+            await Factory.build(
+              'post',
+              {
+                id: 'p139',
+                content: 'Post by user u343',
+              },
+              {
+                author: user,
+                categoryIds,
+              },
+            )
+            await Factory.build(
+              'comment',
+              {
+                id: 'c155',
+                content: 'Comment by user u343',
+              },
+              {
+                author: user,
+              },
+            )
+            await Factory.build(
+              'comment',
+              {
+                id: 'c156',
+                content: "A comment by someone else on user u343's post",
+              },
+              {
+                postId: 'p139',
+              },
+            )
+          })
+
+          it("deletes account, but doesn't delete posts or comments by default", async () => {
+            const expectedResponse = {
+              data: {
+                DeleteUser: {
+                  id: 'u343',
+                  name: 'UNAVAILABLE',
+                  about: 'UNAVAILABLE',
+                  deleted: true,
+                  contributions: [
+                    {
+                      id: 'p139',
+                      content: 'Post by user u343',
+                      contentExcerpt: 'Post by user u343',
+                      deleted: false,
+                      comments: [
+                        {
+                          id: 'c156',
+                          content: "A comment by someone else on user u343's post",
+                          contentExcerpt: "A comment by someone else on user u343's post",
+                          deleted: false,
+                        },
+                      ],
+                    },
+                  ],
+                  comments: [
+                    {
+                      id: 'c155',
+                      content: 'Comment by user u343',
+                      contentExcerpt: 'Comment by user u343',
+                      deleted: false,
+                    },
+                  ],
+                },
+              },
+              errors: undefined,
+            }
+            await expect(
+              mutate({ mutation: deleteUserMutation, variables }),
+            ).resolves.toMatchObject(expectedResponse)
+          })
+
+          describe('deletion of all post requested', () => {
+            beforeEach(() => {
+              variables = { ...variables, resource: ['Post'] }
+            })
+
+            it('on request', async () => {
+              const expectedResponse = {
+                data: {
+                  DeleteUser: {
+                    id: 'u343',
+                    name: 'UNAVAILABLE',
+                    about: 'UNAVAILABLE',
+                    deleted: true,
+                    contributions: [
+                      {
+                        id: 'p139',
+                        content: 'UNAVAILABLE',
+                        contentExcerpt: 'UNAVAILABLE',
+                        deleted: true,
+                        comments: [
+                          {
+                            id: 'c156',
+                            content: 'UNAVAILABLE',
+                            contentExcerpt: 'UNAVAILABLE',
+                            deleted: true,
+                          },
+                        ],
+                      },
+                    ],
+                    comments: [
+                      {
+                        id: 'c155',
+                        content: 'Comment by user u343',
+                        contentExcerpt: 'Comment by user u343',
+                        deleted: false,
+                      },
+                    ],
+                  },
+                },
+                errors: undefined,
+              }
+              await expect(
+                mutate({ mutation: deleteUserMutation, variables }),
+              ).resolves.toMatchObject(expectedResponse)
+            })
+
+            it('deletes user avatar and post hero images', async () => {
+              await expect(neode.all('Image')).resolves.toHaveLength(22)
+              await mutate({ mutation: deleteUserMutation, variables })
+              await expect(neode.all('Image')).resolves.toHaveLength(20)
+            })
+          })
+
+          describe('deletion of all comments requested', () => {
+            beforeEach(() => {
+              variables = { ...variables, resource: ['Comment'] }
+            })
+
+            it('marks comments as deleted', async () => {
+              const expectedResponse = {
+                data: {
+                  DeleteUser: {
+                    id: 'u343',
+                    name: 'UNAVAILABLE',
+                    about: 'UNAVAILABLE',
+                    deleted: true,
+                    contributions: [
+                      {
+                        id: 'p139',
+                        content: 'Post by user u343',
+                        contentExcerpt: 'Post by user u343',
+                        deleted: false,
+                        comments: [
+                          {
+                            id: 'c156',
+                            content: "A comment by someone else on user u343's post",
+                            contentExcerpt: "A comment by someone else on user u343's post",
+                            deleted: false,
+                          },
+                        ],
+                      },
+                    ],
+                    comments: [
+                      {
+                        id: 'c155',
+                        content: 'UNAVAILABLE',
+                        contentExcerpt: 'UNAVAILABLE',
+                        deleted: true,
+                      },
+                    ],
+                  },
+                },
+                errors: undefined,
+              }
+              await expect(
+                mutate({ mutation: deleteUserMutation, variables }),
+              ).resolves.toMatchObject(expectedResponse)
+            })
+          })
+
+          describe('deletion of all posts and comments requested', () => {
+            beforeEach(() => {
+              variables = { ...variables, resource: ['Comment', 'Post'] }
+            })
+
+            it('marks posts and comments as deleted', async () => {
+              const expectedResponse = {
+                data: {
+                  DeleteUser: {
+                    id: 'u343',
+                    name: 'UNAVAILABLE',
+                    about: 'UNAVAILABLE',
+                    deleted: true,
+                    contributions: [
+                      {
+                        id: 'p139',
+                        content: 'UNAVAILABLE',
+                        contentExcerpt: 'UNAVAILABLE',
+                        deleted: true,
+                        comments: [
+                          {
+                            id: 'c156',
+                            content: 'UNAVAILABLE',
+                            contentExcerpt: 'UNAVAILABLE',
+                            deleted: true,
+                          },
+                        ],
+                      },
+                    ],
+                    comments: [
+                      {
+                        id: 'c155',
+                        content: 'UNAVAILABLE',
+                        contentExcerpt: 'UNAVAILABLE',
+                        deleted: true,
+                      },
+                    ],
+                  },
+                },
+                errors: undefined,
+              }
+              await expect(
+                mutate({ mutation: deleteUserMutation, variables }),
+              ).resolves.toMatchObject(expectedResponse)
+            })
+          })
+        })
+
+        describe('connected `EmailAddress` nodes', () => {
+          it('will be removed completely', async () => {
+            await expect(neode.all('EmailAddress')).resolves.toHaveLength(2)
+            await mutate({ mutation: deleteUserMutation, variables })
+
+            await expect(neode.all('EmailAddress')).resolves.toHaveLength(1)
+          })
+        })
+
+        describe('connected `SocialMedia` nodes', () => {
+          beforeEach(async () => {
+            const socialMedia = await Factory.build('socialMedia')
+            await socialMedia.relateTo(user, 'ownedBy')
+          })
+
+          it('will be removed completely', async () => {
+            await expect(neode.all('SocialMedia')).resolves.toHaveLength(1)
+            await mutate({ mutation: deleteUserMutation, variables })
+            await expect(neode.all('SocialMedia')).resolves.toHaveLength(0)
+          })
+        })
+      })
+    })
+  })
 })

--- a/backend/src/schema/resolvers/users.spec.js
+++ b/backend/src/schema/resolvers/users.spec.js
@@ -6,105 +6,478 @@ import { createTestClient } from 'apollo-server-testing'
 
 const categoryIds = ['cat9']
 let user
+let anotherUser
+let moderator
+let admin
+let authenticatedUser
 
 let query
 let mutate
-let authenticatedUser
 let variables
 
 const driver = getDriver()
 const neode = getNeode()
 
-beforeAll(() => {
-  const { server } = createServer({
-    context: () => {
-      return {
-        driver,
-        neode,
-        user: authenticatedUser,
+
+const deleteUserMutation = gql `
+mutation($id: ID!, $resource: [Deletable]) {
+  DeleteUser(id: $id, resource: $resource) {
+    id
+    name
+    about
+    deleted
+    contributions {
+      id
+      content
+      contentExcerpt
+      deleted
+      comments {
+        id
+        content
+        contentExcerpt
+        deleted
       }
-    },
-  })
-  query = createTestClient(server).query
-  mutate = createTestClient(server).mutate
+    }
+    comments {
+      id
+      content
+      contentExcerpt
+      deleted
+    }
+  }
+}
+`
+
+
+beforeAll(() => {
+    const { server } = createServer({
+        context: () => {
+            return {
+                driver,
+                neode,
+                user: authenticatedUser,
+            }
+        },
+    })
+    query = createTestClient(server).query
+    mutate = createTestClient(server).mutate
+    console.log("z18 beforeAll")
 })
 
-beforeEach(async () => {
-  await cleanDatabase()
+beforeEach(async() => {
+    await cleanDatabase()
 })
 
-describe('User', () => {
-  describe('query by email address', () => {
-    beforeEach(async () => {
-      await Factory.build('user', { name: 'Johnny' }, { email: 'any-email-address@example.org' })
+
+
+
+
+
+describe('Delete a User as another user', () => {
+    beforeEach(async() => {
+        variables = { id: ' u343', resource: [] }
+
+        user = await Factory.build('user', {
+            name: 'My name should be deleted',
+            about: 'along with my about',
+            id: 'u343',
+        })
     })
 
-    const userQuery = gql`
+    beforeEach(async() => {
+        const anotherUser = await Factory.build(
+            'user', {
+                role: 'user',
+            }, {
+                email: 'user@example.org',
+                password: '1234',
+            },
+        )
+
+        authenticatedUser = await anotherUser.toJson()
+    })
+
+    it("an ordinary user has no authorization to delete another user's account", async() => {
+        const { errors } = await mutate({ mutation: deleteUserMutation, variables })
+        expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+    })
+})
+
+describe('Delete a User as moderator', () => {
+    beforeEach(async() => {
+        variables = { id: ' u343', resource: [] }
+
+        user = await Factory.build('user', {
+            name: 'My name should be deleted',
+            about: 'along with my about',
+            id: 'u343',
+        })
+    })
+
+    beforeEach(async() => {
+        const moderator = await Factory.build(
+            'user', {
+                role: 'moderator',
+            }, {
+                email: 'moderator@example.org',
+                password: '1234',
+            },
+        )
+
+        authenticatedUser = await moderator.toJson()
+    })
+
+    it('moderator is not allowed to delete other user accounts', async() => {
+        const { errors } = await mutate({ mutation: deleteUserMutation, variables })
+        expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+    })
+})
+
+
+describe('User', () => {
+    describe('query by email address', () => {
+        beforeEach(async() => {
+            await Factory.build('user', { name: 'Johnny' }, { email: 'any-email-address@example.org' })
+        })
+
+        const userQuery = gql `
       query($email: String) {
         User(email: $email) {
           name
         }
       }
     `
-    const variables = { email: 'any-email-address@example.org' }
+        const variables = { email: 'any-email-address@example.org' }
 
-    it('is forbidden', async () => {
-      await expect(query({ query: userQuery, variables })).resolves.toMatchObject({
-        errors: [{ message: 'Not Authorised!' }],
-      })
-    })
-
-    describe('as admin', () => {
-      beforeEach(async () => {
-        const admin = await Factory.build(
-          'user',
-          {
-            role: 'admin',
-          },
-          {
-            email: 'admin@example.org',
-            password: '1234',
-          },
-        )
-        authenticatedUser = await admin.toJson()
-      })
-
-      it('is permitted', async () => {
-        await expect(query({ query: userQuery, variables })).resolves.toMatchObject({
-          data: { User: [{ name: 'Johnny' }] },
-          errors: undefined,
+        it('is forbidden', async() => {
+            await expect(query({ query: userQuery, variables })).resolves.toMatchObject({
+                errors: [{ message: 'Not Authorised!' }],
+            })
         })
-      })
 
-      it('non-existing email address, issue #2294', async () => {
-        // see: https://github.com/Human-Connection/Human-Connection/issues/2294
-        await expect(
-          query({
-            query: userQuery,
-            variables: {
-              email: 'this-email-does-not-exist@example.org',
-            },
-          }),
-        ).resolves.toMatchObject({
-          data: { User: [] },
-          errors: undefined,
+        describe('as admin', () => {
+            beforeEach(async() => {
+                const admin = await Factory.build(
+                    'user', {
+                        role: 'admin',
+                    }, {
+                        email: 'admin@example.org',
+                        password: '1234',
+                    },
+                )
+                authenticatedUser = await admin.toJson()
+            })
+
+            it('is permitted', async() => {
+                await expect(query({ query: userQuery, variables })).resolves.toMatchObject({
+                    data: { User: [{ name: 'Johnny' }] },
+                    errors: undefined,
+                })
+            })
+
+            it('non-existing email address, issue #2294', async() => {
+                // see: https://github.com/Human-Connection/Human-Connection/issues/2294
+                await expect(
+                    query({
+                        query: userQuery,
+                        variables: {
+                            email: 'this-email-does-not-exist@example.org',
+                        },
+                    }),
+                ).resolves.toMatchObject({
+                    data: { User: [] },
+                    errors: undefined,
+                })
+            })
         })
-      })
     })
-  })
 })
 
+
+
+
+
+describe('Delete a User as admin', () => {
+
+    beforeEach(async() => {
+        variables = { id: ' u343', resource: [] }
+
+        user = await Factory.build('user', {
+            name: 'My name should be deleted',
+            about: 'along with my about',
+            id: 'u343',
+        })
+    })
+
+    describe('authenticated as Admin', () => {
+        beforeEach(async() => {
+            admin = await Factory.build(
+                'user', {
+                    role: 'admin',
+                }, {
+                    email: 'admin@example.org',
+                    password: '1234',
+                },
+            )
+            authenticatedUser = await admin.toJson()
+        })
+
+        describe('deleting a user account', () => {
+            beforeEach(() => {
+                variables = {...variables, id: 'u343' }
+            })
+
+            describe('given posts and comments', () => {
+                beforeEach(async() => {
+                    await Factory.build('category', {
+                        id: 'cat9',
+                        name: 'Democracy & Politics',
+                        icon: 'university',
+                    })
+                    await Factory.build(
+                        'post', {
+                            id: 'p139',
+                            content: 'Post by user u343',
+                        }, {
+                            author: user,
+                            categoryIds,
+                        },
+                    )
+                    await Factory.build(
+                        'comment', {
+                            id: 'c155',
+                            content: 'Comment by user u343',
+                        }, {
+                            author: user,
+                        },
+                    )
+                    await Factory.build(
+                        'comment', {
+                            id: 'c156',
+                            content: "A comment by someone else on user u343's post",
+                        }, {
+                            postId: 'p139',
+                        },
+                    )
+                })
+
+                it("deletes account, but doesn't delete posts or comments by default", async() => {
+                    const expectedResponse = {
+                        data: {
+                            DeleteUser: {
+                                id: 'u343',
+                                name: 'UNAVAILABLE',
+                                about: 'UNAVAILABLE',
+                                deleted: true,
+                                contributions: [{
+                                    id: 'p139',
+                                    content: 'Post by user u343',
+                                    contentExcerpt: 'Post by user u343',
+                                    deleted: false,
+                                    comments: [{
+                                        id: 'c156',
+                                        content: "A comment by someone else on user u343's post",
+                                        contentExcerpt: "A comment by someone else on user u343's post",
+                                        deleted: false,
+                                    }, ],
+                                }, ],
+                                comments: [{
+                                    id: 'c155',
+                                    content: 'Comment by user u343',
+                                    contentExcerpt: 'Comment by user u343',
+                                    deleted: false,
+                                }, ],
+                            },
+                        },
+                        errors: undefined,
+                    }
+                    await expect(
+                        mutate({ mutation: deleteUserMutation, variables }),
+                    ).resolves.toMatchObject(expectedResponse)
+                })
+
+                describe('deletion of all post requested', () => {
+
+                    beforeEach(() => {
+                        variables = {...variables, resource: ['Post'] }
+                    })
+
+
+                    it('on request', async() => {
+                        const expectedResponse = {
+                            data: {
+                                DeleteUser: {
+                                    id: 'u343',
+                                    name: 'UNAVAILABLE',
+                                    about: 'UNAVAILABLE',
+                                    deleted: true,
+                                    contributions: [{
+                                        id: 'p139',
+                                        content: 'UNAVAILABLE',
+                                        contentExcerpt: 'UNAVAILABLE',
+                                        deleted: true,
+                                        comments: [{
+                                            id: 'c156',
+                                            content: 'UNAVAILABLE',
+                                            contentExcerpt: 'UNAVAILABLE',
+                                            deleted: true,
+                                        }, ],
+                                    }, ],
+                                    comments: [{
+                                        id: 'c155',
+                                        content: 'Comment by user u343',
+                                        contentExcerpt: 'Comment by user u343',
+                                        deleted: false,
+                                    }, ],
+                                },
+                            },
+                            errors: undefined,
+                        }
+                        await expect(
+                            mutate({ mutation: deleteUserMutation, variables }),
+                        ).resolves.toMatchObject(expectedResponse)
+                    })
+
+                    it('deletes user avatar and post hero images', async() => {
+                        await expect(neode.all('Image')).resolves.toHaveLength(22)
+                        await mutate({ mutation: deleteUserMutation, variables })
+                        await expect(neode.all('Image')).resolves.toHaveLength(20)
+                    })
+
+                })
+
+                describe('deletion of all comments requested', () => {
+                    beforeEach(() => {
+                        variables = {...variables, resource: ['Comment'] }
+                    })
+
+
+                    it('marks comments as deleted', async() => {
+                        const expectedResponse = {
+                            data: {
+                                DeleteUser: {
+                                    id: 'u343',
+                                    name: 'UNAVAILABLE',
+                                    about: 'UNAVAILABLE',
+                                    deleted: true,
+                                    contributions: [{
+                                        id: 'p139',
+                                        content: 'Post by user u343',
+                                        contentExcerpt: 'Post by user u343',
+                                        deleted: false,
+                                        comments: [{
+                                            id: 'c156',
+                                            content: "A comment by someone else on user u343's post",
+                                            contentExcerpt: "A comment by someone else on user u343's post",
+                                            deleted: false,
+                                        }, ],
+                                    }, ],
+                                    comments: [{
+                                        id: 'c155',
+                                        content: 'UNAVAILABLE',
+                                        contentExcerpt: 'UNAVAILABLE',
+                                        deleted: true,
+                                    }, ],
+                                },
+                            },
+                            errors: undefined,
+                        }
+                        await expect(
+                            mutate({ mutation: deleteUserMutation, variables }),
+                        ).resolves.toMatchObject(expectedResponse)
+                    })
+
+
+
+                })
+
+                describe('deletion of all posts and comments requested', () => {
+                    beforeEach(() => {
+                        variables = {...variables,
+                            resource: ['Comment', 'Post']
+                        }
+                    })
+
+                    it('marks posts and comments as deleted', async() => {
+                        const expectedResponse = {
+                            data: {
+                                DeleteUser: {
+                                    id: 'u343',
+                                    name: 'UNAVAILABLE',
+                                    about: 'UNAVAILABLE',
+                                    deleted: true,
+                                    contributions: [{
+                                        id: 'p139',
+                                        content: 'UNAVAILABLE',
+                                        contentExcerpt: 'UNAVAILABLE',
+                                        deleted: true,
+                                        comments: [{
+                                            id: 'c156',
+                                            content: 'UNAVAILABLE',
+                                            contentExcerpt: 'UNAVAILABLE',
+                                            deleted: true,
+                                        }, ],
+                                    }, ],
+                                    comments: [{
+                                        id: 'c155',
+                                        content: 'UNAVAILABLE',
+                                        contentExcerpt: 'UNAVAILABLE',
+                                        deleted: true,
+                                    }, ],
+                                },
+                            },
+                            errors: undefined,
+                        }
+                        await expect(
+                            mutate({ mutation: deleteUserMutation, variables }),
+                        ).resolves.toMatchObject(expectedResponse)
+                    })
+                })
+            })
+
+            describe('connected `EmailAddress` nodes', () => {
+                it('will be removed completely', async() => {
+                    await expect(neode.all('EmailAddress')).resolves.toHaveLength(2)
+                    await mutate({ mutation: deleteUserMutation, variables })
+
+                    await expect(neode.all('EmailAddress')).resolves.toHaveLength(1)
+                })
+            })
+
+            describe('connected `SocialMedia` nodes', () => {
+                beforeEach(async() => {
+                    const socialMedia = await Factory.build('socialMedia')
+                    await socialMedia.relateTo(user, 'ownedBy')
+                })
+
+                it('will be removed completely', async() => {
+                    await expect(neode.all('SocialMedia')).resolves.toHaveLength(1)
+                    await mutate({ mutation: deleteUserMutation, variables })
+                    await expect(neode.all('SocialMedia')).resolves.toHaveLength(0)
+                })
+            })
+        })
+    })
+
+
+
+})
+
+
+
+
+
 describe('UpdateUser', () => {
-  let variables
+    let variables
 
-  beforeEach(async () => {
-    variables = {
-      id: 'u47',
-      name: 'John Doughnut',
-    }
-  })
+    beforeEach(async() => {
+        variables = {
+            id: 'u47',
+            name: 'John Doughnut',
+        }
+    })
 
-  const updateUserMutation = gql`
+    const updateUserMutation = gql `
     mutation(
       $id: ID!
       $name: String
@@ -126,795 +499,116 @@ describe('UpdateUser', () => {
     }
   `
 
-  beforeEach(async () => {
-    user = await Factory.build(
-      'user',
-      {
-        id: 'u47',
-        name: 'John Doe',
-        termsAndConditionsAgreedVersion: null,
-        termsAndConditionsAgreedAt: null,
-        allowEmbedIframes: false,
-      },
-      {
-        email: 'user@example.org',
-      },
-    )
-  })
-
-  describe('as another user', () => {
-    beforeEach(async () => {
-      const someoneElse = await Factory.build(
-        'user',
-        {
-          name: 'James Doe',
-        },
-        {
-          email: 'someone-else@example.org',
-        },
-      )
-
-      authenticatedUser = await someoneElse.toJson()
-    })
-
-    it('is not allowed to change other user accounts', async () => {
-      const { errors } = await mutate({ mutation: updateUserMutation, variables })
-      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-    })
-  })
-
-  describe('as the same user', () => {
-    beforeEach(async () => {
-      authenticatedUser = await user.toJson()
-    })
-
-    it('updates the name', async () => {
-      const expected = {
-        data: {
-          UpdateUser: {
-            id: 'u47',
-            name: 'John Doughnut',
-          },
-        },
-        errors: undefined,
-      }
-      await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
-        expected,
-      )
-    })
-
-    describe('given a new agreed version of terms and conditions', () => {
-      beforeEach(async () => {
-        variables = { ...variables, termsAndConditionsAgreedVersion: '0.0.2' }
-      })
-      it('update termsAndConditionsAgreedVersion', async () => {
-        const expected = {
-          data: {
-            UpdateUser: expect.objectContaining({
-              termsAndConditionsAgreedVersion: '0.0.2',
-              termsAndConditionsAgreedAt: expect.any(String),
-            }),
-          },
-          errors: undefined,
-        }
-
-        await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
-          expected,
+    beforeEach(async() => {
+        user = await Factory.build(
+            'user', {
+                id: 'u47',
+                name: 'John Doe',
+                termsAndConditionsAgreedVersion: null,
+                termsAndConditionsAgreedAt: null,
+                allowEmbedIframes: false,
+            }, {
+                email: 'user@example.org',
+            },
         )
-      })
     })
 
-    describe('given any attribute other than termsAndConditionsAgreedVersion', () => {
-      beforeEach(async () => {
-        variables = { ...variables, name: 'any name' }
-      })
-      it('update termsAndConditionsAgreedVersion', async () => {
-        const expected = {
-          data: {
-            UpdateUser: expect.objectContaining({
-              termsAndConditionsAgreedVersion: null,
-              termsAndConditionsAgreedAt: null,
-            }),
-          },
-          errors: undefined,
-        }
+    describe('as another user', () => {
+        beforeEach(async() => {
+            const someoneElse = await Factory.build(
+                'user', {
+                    name: 'James Doe',
+                }, {
+                    email: 'someone-else@example.org',
+                },
+            )
 
-        await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
-          expected,
-        )
-      })
-    })
-
-    it('rejects if version of terms and conditions has wrong format', async () => {
-      variables = {
-        ...variables,
-        termsAndConditionsAgreedVersion: 'invalid version format',
-      }
-      const { errors } = await mutate({ mutation: updateUserMutation, variables })
-      expect(errors[0]).toHaveProperty('message', 'Invalid version format!')
-    })
-
-    it('supports updating location', async () => {
-      variables = { ...variables, locationName: 'Hamburg, New Jersey, United States of America' }
-      await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject({
-        data: { UpdateUser: { locationName: 'Hamburg, New Jersey, United States of America' } },
-        errors: undefined,
-      })
-    })
-  })
-})
-
-describe('DeleteUser', () => {
-  const deleteUserMutation = gql`
-    mutation($id: ID!, $resource: [Deletable]) {
-      DeleteUser(id: $id, resource: $resource) {
-        id
-        name
-        about
-        deleted
-        contributions {
-          id
-          content
-          contentExcerpt
-          deleted
-          comments {
-            id
-            content
-            contentExcerpt
-            deleted
-          }
-        }
-        comments {
-          id
-          content
-          contentExcerpt
-          deleted
-        }
-      }
-    }
-  `
-  describe('as another user', () => {
-    beforeEach(async () => {
-      variables = { id: ' u343', resource: [] }
-
-      user = await Factory.build('user', {
-        name: 'My name should be deleted',
-        about: 'along with my about',
-        id: 'u343',
-      })
-    })
-
-    beforeEach(async () => {
-      const anotherUser = await Factory.build(
-        'user',
-        {
-          role: 'user',
-        },
-        {
-          email: 'user@example.org',
-          password: '1234',
-        },
-      )
-
-      authenticatedUser = await anotherUser.toJson()
-    })
-
-    it("an ordinary user has no authorization to delete another user's account", async () => {
-      const { errors } = await mutate({ mutation: deleteUserMutation, variables })
-      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-    })
-  })
-
-  describe('as moderator', () => {
-    beforeEach(async () => {
-      variables = { id: ' u343', resource: [] }
-
-      user = await Factory.build('user', {
-        name: 'My name should be deleted',
-        about: 'along with my about',
-        id: 'u343',
-      })
-    })
-
-    beforeEach(async () => {
-      const moderator = await Factory.build(
-        'user',
-        {
-          role: 'moderator',
-        },
-        {
-          email: 'moderator@example.org',
-          password: '1234',
-        },
-      )
-
-      authenticatedUser = await moderator.toJson()
-    })
-
-    it('moderator is not allowed to delete other user accounts', async () => {
-      const { errors } = await mutate({ mutation: deleteUserMutation, variables })
-      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-    })
-  })
-
-  describe('as admin', () => {
-    beforeEach(async () => {
-      variables = { id: ' u343', resource: [] }
-
-      user = await Factory.build('user', {
-        name: 'My name should be deleted',
-        about: 'along with my about',
-        id: 'u343',
-      })
-    })
-
-    describe('authenticated as Admin', () => {
-      beforeEach(async () => {
-        const admin = await Factory.build(
-          'user',
-          {
-            role: 'admin',
-          },
-          {
-            email: 'admin@example.org',
-            password: '1234',
-          },
-        )
-        authenticatedUser = await admin.toJson()
-      })
-
-      describe('deleting a user account', () => {
-        beforeEach(() => {
-          variables = { ...variables, id: 'u343' }
+            authenticatedUser = await someoneElse.toJson()
         })
 
-        describe('given posts and comments', () => {
-          beforeEach(async () => {
-            await Factory.build('category', {
-              id: 'cat9',
-              name: 'Democracy & Politics',
-              icon: 'university',
-            })
-            await Factory.build(
-              'post',
-              {
-                id: 'p139',
-                content: 'Post by user u343',
-              },
-              {
-                author: user,
-                categoryIds,
-              },
-            )
-            await Factory.build(
-              'comment',
-              {
-                id: 'c155',
-                content: 'Comment by user u343',
-              },
-              {
-                author: user,
-              },
-            )
-            await Factory.build(
-              'comment',
-              {
-                id: 'c156',
-                content: "A comment by someone else on user u343's post",
-              },
-              {
-                postId: 'p139',
-              },
-            )
-          })
+        it('is not allowed to change other user accounts', async() => {
+            const { errors } = await mutate({ mutation: updateUserMutation, variables })
+            expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+        })
+    })
 
-          it("deletes account, but doesn't delete posts or comments by default", async () => {
-            const expectedResponse = {
-              data: {
-                DeleteUser: {
-                  id: 'u343',
-                  name: 'UNAVAILABLE',
-                  about: 'UNAVAILABLE',
-                  deleted: true,
-                  contributions: [
-                    {
-                      id: 'p139',
-                      content: 'Post by user u343',
-                      contentExcerpt: 'Post by user u343',
-                      deleted: false,
-                      comments: [
-                        {
-                          id: 'c156',
-                          content: "A comment by someone else on user u343's post",
-                          contentExcerpt: "A comment by someone else on user u343's post",
-                          deleted: false,
-                        },
-                      ],
+    describe('as the same user', () => {
+        beforeEach(async() => {
+            authenticatedUser = await user.toJson()
+        })
+
+        it('updates the name', async() => {
+            const expected = {
+                data: {
+                    UpdateUser: {
+                        id: 'u47',
+                        name: 'John Doughnut',
                     },
-                  ],
-                  comments: [
-                    {
-                      id: 'c155',
-                      content: 'Comment by user u343',
-                      contentExcerpt: 'Comment by user u343',
-                      deleted: false,
-                    },
-                  ],
                 },
-              },
-              errors: undefined,
+                errors: undefined,
             }
-            await expect(
-              mutate({ mutation: deleteUserMutation, variables }),
-            ).resolves.toMatchObject(expectedResponse)
-          })
+            await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
+                expected,
+            )
+        })
 
-          describe('deletion of all post requested', () => {
-            beforeEach(() => {
-              variables = { ...variables, resource: ['Post'] }
+        describe('given a new agreed version of terms and conditions', () => {
+            beforeEach(async() => {
+                variables = {...variables, termsAndConditionsAgreedVersion: '0.0.2' }
             })
-
-            describe("marks user's posts as deleted", () => {
-              it('on request', async () => {
-                const expectedResponse = {
-                  data: {
-                    DeleteUser: {
-                      id: 'u343',
-                      name: 'UNAVAILABLE',
-                      about: 'UNAVAILABLE',
-                      deleted: true,
-                      contributions: [
-                        {
-                          id: 'p139',
-                          content: 'UNAVAILABLE',
-                          contentExcerpt: 'UNAVAILABLE',
-                          deleted: true,
-                          comments: [
-                            {
-                              id: 'c156',
-                              content: 'UNAVAILABLE',
-                              contentExcerpt: 'UNAVAILABLE',
-                              deleted: true,
-                            },
-                          ],
-                        },
-                      ],
-                      comments: [
-                        {
-                          id: 'c155',
-                          content: 'Comment by user u343',
-                          contentExcerpt: 'Comment by user u343',
-                          deleted: false,
-                        },
-                      ],
+            it('update termsAndConditionsAgreedVersion', async() => {
+                const expected = {
+                    data: {
+                        UpdateUser: expect.objectContaining({
+                            termsAndConditionsAgreedVersion: '0.0.2',
+                            termsAndConditionsAgreedAt: expect.any(String),
+                        }),
                     },
-                  },
-                  errors: undefined,
+                    errors: undefined,
                 }
-                await expect(
-                  mutate({ mutation: deleteUserMutation, variables }),
-                ).resolves.toMatchObject(expectedResponse)
-              })
 
-              it('deletes user avatar and post hero images', async () => {
-                await expect(neode.all('Image')).resolves.toHaveLength(22)
-                await mutate({ mutation: deleteUserMutation, variables })
-                await expect(neode.all('Image')).resolves.toHaveLength(20)
-              })
+                await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
+                    expected,
+                )
             })
-          })
-
-          describe('deletion of all comments requested', () => {
-            beforeEach(() => {
-              variables = { ...variables, resource: ['Comment'] }
-            })
-
-            it('marks comments as deleted', async () => {
-              const expectedResponse = {
-                data: {
-                  DeleteUser: {
-                    id: 'u343',
-                    name: 'UNAVAILABLE',
-                    about: 'UNAVAILABLE',
-                    deleted: true,
-                    contributions: [
-                      {
-                        id: 'p139',
-                        content: 'Post by user u343',
-                        contentExcerpt: 'Post by user u343',
-                        deleted: false,
-                        comments: [
-                          {
-                            id: 'c156',
-                            content: "A comment by someone else on user u343's post",
-                            contentExcerpt: "A comment by someone else on user u343's post",
-                            deleted: false,
-                          },
-                        ],
-                      },
-                    ],
-                    comments: [
-                      {
-                        id: 'c155',
-                        content: 'UNAVAILABLE',
-                        contentExcerpt: 'UNAVAILABLE',
-                        deleted: true,
-                      },
-                    ],
-                  },
-                },
-                errors: undefined,
-              }
-              await expect(
-                mutate({ mutation: deleteUserMutation, variables }),
-              ).resolves.toMatchObject(expectedResponse)
-            })
-          })
-
-          describe('deletion of all posts and comments requested', () => {
-            beforeEach(() => {
-              variables = { ...variables, resource: ['Post', 'Comment'] }
-            })
-
-            it('marks posts and comments as deleted', async () => {
-              const expectedResponse = {
-                data: {
-                  DeleteUser: {
-                    id: 'u343',
-                    name: 'UNAVAILABLE',
-                    about: 'UNAVAILABLE',
-                    deleted: true,
-                    contributions: [
-                      {
-                        id: 'p139',
-                        content: 'UNAVAILABLE',
-                        contentExcerpt: 'UNAVAILABLE',
-                        deleted: true,
-                        comments: [
-                          {
-                            id: 'c156',
-                            content: 'UNAVAILABLE',
-                            contentExcerpt: 'UNAVAILABLE',
-                            deleted: true,
-                          },
-                        ],
-                      },
-                    ],
-                    comments: [
-                      {
-                        id: 'c155',
-                        content: 'UNAVAILABLE',
-                        contentExcerpt: 'UNAVAILABLE',
-                        deleted: true,
-                      },
-                    ],
-                  },
-                },
-                errors: undefined,
-              }
-              await expect(
-                mutate({ mutation: deleteUserMutation, variables }),
-              ).resolves.toMatchObject(expectedResponse)
-            })
-          })
         })
 
-        describe('connected `EmailAddress` nodes', () => {
-          it('will be removed completely', async () => {
-            await expect(neode.all('EmailAddress')).resolves.toHaveLength(2)
-            await mutate({ mutation: deleteUserMutation, variables })
-            await expect(neode.all('EmailAddress')).resolves.toHaveLength(1)
-          })
-        })
-
-        describe('connected `SocialMedia` nodes', () => {
-          beforeEach(async () => {
-            const socialMedia = await Factory.build('socialMedia')
-            await socialMedia.relateTo(user, 'ownedBy')
-          })
-
-          it('will be removed completely', async () => {
-            await expect(neode.all('SocialMedia')).resolves.toHaveLength(1)
-            await mutate({ mutation: deleteUserMutation, variables })
-            await expect(neode.all('SocialMedia')).resolves.toHaveLength(0)
-          })
-        })
-      })
-    })
-  })
-
-  describe('user deletes his own account', () => {
-    beforeEach(async () => {
-      variables = { id: 'u343', resource: [] }
-
-      user = await Factory.build('user', {
-        name: 'My name should be deleted',
-        about: 'along with my about',
-        id: 'u343',
-      })
-      await Factory.build(
-        'user',
-        {
-          id: 'not-my-account',
-        },
-        {
-          email: 'friends-account@example.org',
-        },
-      )
-    })
-
-    describe('authenticated', () => {
-      beforeEach(async () => {
-        authenticatedUser = await user.toJson()
-      })
-
-      describe("attempting to delete another user's account", () => {
-        beforeEach(() => {
-          variables = { ...variables, id: 'not-my-account' }
-        })
-
-        it('throws an authorization error', async () => {
-          const { errors } = await mutate({ mutation: deleteUserMutation, variables })
-          expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-        })
-      })
-
-      describe('attempting to delete my own account', () => {
-        beforeEach(() => {
-          variables = { ...variables, id: 'u343' }
-        })
-
-        describe('given posts and comments', () => {
-          beforeEach(async () => {
-            await Factory.build('category', {
-              id: 'cat9',
-              name: 'Democracy & Politics',
-              icon: 'university',
+        describe('given any attribute other than termsAndConditionsAgreedVersion', () => {
+            beforeEach(async() => {
+                variables = {...variables, name: 'any name' }
             })
-            await Factory.build(
-              'post',
-              {
-                id: 'p139',
-                content: 'Post by user u343',
-              },
-              {
-                author: user,
-                categoryIds,
-              },
-            )
-            await Factory.build(
-              'comment',
-              {
-                id: 'c155',
-                content: 'Comment by user u343',
-              },
-              {
-                author: user,
-              },
-            )
-            await Factory.build(
-              'comment',
-              {
-                id: 'c156',
-                content: "A comment by someone else on user u343's post",
-              },
-              {
-                postId: 'p139',
-              },
-            )
-          })
-
-          it("deletes my account, but doesn't delete posts or comments by default", async () => {
-            const expectedResponse = {
-              data: {
-                DeleteUser: {
-                  id: 'u343',
-                  name: 'UNAVAILABLE',
-                  about: 'UNAVAILABLE',
-                  deleted: true,
-                  contributions: [
-                    {
-                      id: 'p139',
-                      content: 'Post by user u343',
-                      contentExcerpt: 'Post by user u343',
-                      deleted: false,
-                      comments: [
-                        {
-                          id: 'c156',
-                          content: "A comment by someone else on user u343's post",
-                          contentExcerpt: "A comment by someone else on user u343's post",
-                          deleted: false,
-                        },
-                      ],
+            it('update termsAndConditionsAgreedVersion', async() => {
+                const expected = {
+                    data: {
+                        UpdateUser: expect.objectContaining({
+                            termsAndConditionsAgreedVersion: null,
+                            termsAndConditionsAgreedAt: null,
+                        }),
                     },
-                  ],
-                  comments: [
-                    {
-                      id: 'c155',
-                      content: 'Comment by user u343',
-                      contentExcerpt: 'Comment by user u343',
-                      deleted: false,
-                    },
-                  ],
-                },
-              },
-              errors: undefined,
+                    errors: undefined,
+                }
+
+                await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
+                    expected,
+                )
+            })
+        })
+
+        it('rejects if version of terms and conditions has wrong format', async() => {
+            variables = {
+                ...variables,
+                termsAndConditionsAgreedVersion: 'invalid version format',
             }
-            await expect(
-              mutate({ mutation: deleteUserMutation, variables }),
-            ).resolves.toMatchObject(expectedResponse)
-          })
-
-          describe('deletion of all post requested', () => {
-            beforeEach(() => {
-              variables = { ...variables, resource: ['Post'] }
-            })
-
-            describe("marks user's posts as deleted", () => {
-              it('posts on request', async () => {
-                const expectedResponse = {
-                  data: {
-                    DeleteUser: {
-                      id: 'u343',
-                      name: 'UNAVAILABLE',
-                      about: 'UNAVAILABLE',
-                      deleted: true,
-                      contributions: [
-                        {
-                          id: 'p139',
-                          content: 'UNAVAILABLE',
-                          contentExcerpt: 'UNAVAILABLE',
-                          deleted: true,
-                          comments: [
-                            {
-                              id: 'c156',
-                              content: 'UNAVAILABLE',
-                              contentExcerpt: 'UNAVAILABLE',
-                              deleted: true,
-                            },
-                          ],
-                        },
-                      ],
-                      comments: [
-                        {
-                          id: 'c155',
-                          content: 'Comment by user u343',
-                          contentExcerpt: 'Comment by user u343',
-                          deleted: false,
-                        },
-                      ],
-                    },
-                  },
-                  errors: undefined,
-                }
-                await expect(
-                  mutate({ mutation: deleteUserMutation, variables }),
-                ).resolves.toMatchObject(expectedResponse)
-              })
-
-              it('deletes user avatar and post hero images', async () => {
-                await expect(neode.all('Image')).resolves.toHaveLength(22)
-                await mutate({ mutation: deleteUserMutation, variables })
-                await expect(neode.all('Image')).resolves.toHaveLength(20)
-              })
-            })
-          })
-
-          describe('deletion of all comments requested', () => {
-            beforeEach(() => {
-              variables = { ...variables, resource: ['Comment'] }
-            })
-
-            it('marks comments as deleted', async () => {
-              const expectedResponse = {
-                data: {
-                  DeleteUser: {
-                    id: 'u343',
-                    name: 'UNAVAILABLE',
-                    about: 'UNAVAILABLE',
-                    deleted: true,
-                    contributions: [
-                      {
-                        id: 'p139',
-                        content: 'Post by user u343',
-                        contentExcerpt: 'Post by user u343',
-                        deleted: false,
-                        comments: [
-                          {
-                            id: 'c156',
-                            content: "A comment by someone else on user u343's post",
-                            contentExcerpt: "A comment by someone else on user u343's post",
-                            deleted: false,
-                          },
-                        ],
-                      },
-                    ],
-                    comments: [
-                      {
-                        id: 'c155',
-                        content: 'UNAVAILABLE',
-                        contentExcerpt: 'UNAVAILABLE',
-                        deleted: true,
-                      },
-                    ],
-                  },
-                },
-                errors: undefined,
-              }
-              await expect(
-                mutate({ mutation: deleteUserMutation, variables }),
-              ).resolves.toMatchObject(expectedResponse)
-            })
-          })
-          describe('deletion of all post and comments requested', () => {
-            beforeEach(() => {
-              variables = { ...variables, resource: ['Post', 'Comment'] }
-            })
-
-            it('marks posts and comments as deleted', async () => {
-              const expectedResponse = {
-                data: {
-                  DeleteUser: {
-                    id: 'u343',
-                    name: 'UNAVAILABLE',
-                    about: 'UNAVAILABLE',
-                    deleted: true,
-                    contributions: [
-                      {
-                        id: 'p139',
-                        content: 'UNAVAILABLE',
-                        contentExcerpt: 'UNAVAILABLE',
-                        deleted: true,
-                        comments: [
-                          {
-                            id: 'c156',
-                            content: 'UNAVAILABLE',
-                            contentExcerpt: 'UNAVAILABLE',
-                            deleted: true,
-                          },
-                        ],
-                      },
-                    ],
-                    comments: [
-                      {
-                        id: 'c155',
-                        content: 'UNAVAILABLE',
-                        contentExcerpt: 'UNAVAILABLE',
-                        deleted: true,
-                      },
-                    ],
-                  },
-                },
-                errors: undefined,
-              }
-              await expect(
-                mutate({ mutation: deleteUserMutation, variables }),
-              ).resolves.toMatchObject(expectedResponse)
-            })
-          })
+            const { errors } = await mutate({ mutation: updateUserMutation, variables })
+            expect(errors[0]).toHaveProperty('message', 'Invalid version format!')
         })
-      })
-    })
 
-    describe('connected `EmailAddress` nodes', () => {
-      it('will be removed completely', async () => {
-        await expect(neode.all('EmailAddress')).resolves.toHaveLength(2)
-        await mutate({ mutation: deleteUserMutation, variables })
-        await expect(neode.all('EmailAddress')).resolves.toHaveLength(1)
-      })
+        it('supports updating location', async() => {
+            variables = {...variables, locationName: 'Hamburg, New Jersey, United States of America' }
+            await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject({
+                data: { UpdateUser: { locationName: 'Hamburg, New Jersey, United States of America' } },
+                errors: undefined,
+            })
+        })
     })
-
-    describe('connected `SocialMedia` nodes', () => {
-      beforeEach(async () => {
-        const socialMedia = await Factory.build('socialMedia')
-        await socialMedia.relateTo(user, 'ownedBy')
-      })
-
-      it('will be removed completely', async () => {
-        await expect(neode.all('SocialMedia')).resolves.toHaveLength(1)
-        await mutate({ mutation: deleteUserMutation, variables })
-        await expect(neode.all('SocialMedia')).resolves.toHaveLength(0)
-      })
-    })
-  })
 })

--- a/backend/src/schema/resolvers/users.spec.js
+++ b/backend/src/schema/resolvers/users.spec.js
@@ -18,19 +18,25 @@ let variables
 const driver = getDriver()
 const neode = getNeode()
 
-
-const deleteUserMutation = gql `
-mutation($id: ID!, $resource: [Deletable]) {
-  DeleteUser(id: $id, resource: $resource) {
-    id
-    name
-    about
-    deleted
-    contributions {
+const deleteUserMutation = gql`
+  mutation($id: ID!, $resource: [Deletable]) {
+    DeleteUser(id: $id, resource: $resource) {
       id
-      content
-      contentExcerpt
+      name
+      about
       deleted
+      contributions {
+        id
+        content
+        contentExcerpt
+        deleted
+        comments {
+          id
+          content
+          contentExcerpt
+          deleted
+        }
+      }
       comments {
         id
         content
@@ -38,446 +44,448 @@ mutation($id: ID!, $resource: [Deletable]) {
         deleted
       }
     }
-    comments {
-      id
-      content
-      contentExcerpt
-      deleted
-    }
   }
-}
 `
 
-
 beforeAll(() => {
-    const { server } = createServer({
-        context: () => {
-            return {
-                driver,
-                neode,
-                user: authenticatedUser,
-            }
-        },
-    })
-    query = createTestClient(server).query
-    mutate = createTestClient(server).mutate
-    console.log("z18 beforeAll")
+  const { server } = createServer({
+    context: () => {
+      return {
+        driver,
+        neode,
+        user: authenticatedUser,
+      }
+    },
+  })
+  query = createTestClient(server).query
+  mutate = createTestClient(server).mutate
 })
 
-beforeEach(async() => {
-    await cleanDatabase()
+beforeEach(async () => {
+  await cleanDatabase()
 })
-
-
-
-
-
 
 describe('Delete a User as another user', () => {
-    beforeEach(async() => {
-        variables = { id: ' u343', resource: [] }
+  beforeEach(async () => {
+    variables = { id: ' u343', resource: [] }
 
-        user = await Factory.build('user', {
-            name: 'My name should be deleted',
-            about: 'along with my about',
-            id: 'u343',
-        })
+    user = await Factory.build('user', {
+      name: 'My name should be deleted',
+      about: 'along with my about',
+      id: 'u343',
     })
+  })
 
-    beforeEach(async() => {
-        const anotherUser = await Factory.build(
-            'user', {
-                role: 'user',
-            }, {
-                email: 'user@example.org',
-                password: '1234',
-            },
-        )
+  beforeEach(async () => {
+    anotherUser = await Factory.build(
+      'user',
+      {
+        role: 'user',
+      },
+      {
+        email: 'user@example.org',
+        password: '1234',
+      },
+    )
 
-        authenticatedUser = await anotherUser.toJson()
-    })
+    authenticatedUser = await anotherUser.toJson()
+  })
 
-    it("an ordinary user has no authorization to delete another user's account", async() => {
-        const { errors } = await mutate({ mutation: deleteUserMutation, variables })
-        expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-    })
+  it("an ordinary user has no authorization to delete another user's account", async () => {
+    const { errors } = await mutate({ mutation: deleteUserMutation, variables })
+    expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+  })
 })
 
 describe('Delete a User as moderator', () => {
-    beforeEach(async() => {
-        variables = { id: ' u343', resource: [] }
+  beforeEach(async () => {
+    variables = { id: ' u343', resource: [] }
 
-        user = await Factory.build('user', {
-            name: 'My name should be deleted',
-            about: 'along with my about',
-            id: 'u343',
-        })
+    user = await Factory.build('user', {
+      name: 'My name should be deleted',
+      about: 'along with my about',
+      id: 'u343',
     })
+  })
 
-    beforeEach(async() => {
-        const moderator = await Factory.build(
-            'user', {
-                role: 'moderator',
-            }, {
-                email: 'moderator@example.org',
-                password: '1234',
-            },
-        )
+  beforeEach(async () => {
+    moderator = await Factory.build(
+      'user',
+      {
+        role: 'moderator',
+      },
+      {
+        email: 'moderator@example.org',
+        password: '1234',
+      },
+    )
 
-        authenticatedUser = await moderator.toJson()
-    })
+    authenticatedUser = await moderator.toJson()
+  })
 
-    it('moderator is not allowed to delete other user accounts', async() => {
-        const { errors } = await mutate({ mutation: deleteUserMutation, variables })
-        expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-    })
+  it('moderator is not allowed to delete other user accounts', async () => {
+    const { errors } = await mutate({ mutation: deleteUserMutation, variables })
+    expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+  })
 })
 
-
 describe('User', () => {
-    describe('query by email address', () => {
-        beforeEach(async() => {
-            await Factory.build('user', { name: 'Johnny' }, { email: 'any-email-address@example.org' })
-        })
+  describe('query by email address', () => {
+    beforeEach(async () => {
+      await Factory.build('user', { name: 'Johnny' }, { email: 'any-email-address@example.org' })
+    })
 
-        const userQuery = gql `
+    const userQuery = gql`
       query($email: String) {
         User(email: $email) {
           name
         }
       }
     `
-        const variables = { email: 'any-email-address@example.org' }
+    const variables = { email: 'any-email-address@example.org' }
 
-        it('is forbidden', async() => {
-            await expect(query({ query: userQuery, variables })).resolves.toMatchObject({
-                errors: [{ message: 'Not Authorised!' }],
-            })
-        })
-
-        describe('as admin', () => {
-            beforeEach(async() => {
-                const admin = await Factory.build(
-                    'user', {
-                        role: 'admin',
-                    }, {
-                        email: 'admin@example.org',
-                        password: '1234',
-                    },
-                )
-                authenticatedUser = await admin.toJson()
-            })
-
-            it('is permitted', async() => {
-                await expect(query({ query: userQuery, variables })).resolves.toMatchObject({
-                    data: { User: [{ name: 'Johnny' }] },
-                    errors: undefined,
-                })
-            })
-
-            it('non-existing email address, issue #2294', async() => {
-                // see: https://github.com/Human-Connection/Human-Connection/issues/2294
-                await expect(
-                    query({
-                        query: userQuery,
-                        variables: {
-                            email: 'this-email-does-not-exist@example.org',
-                        },
-                    }),
-                ).resolves.toMatchObject({
-                    data: { User: [] },
-                    errors: undefined,
-                })
-            })
-        })
+    it('is forbidden', async () => {
+      await expect(query({ query: userQuery, variables })).resolves.toMatchObject({
+        errors: [{ message: 'Not Authorised!' }],
+      })
     })
+
+    describe('as admin', () => {
+      beforeEach(async () => {
+        const admin = await Factory.build(
+          'user',
+          {
+            role: 'admin',
+          },
+          {
+            email: 'admin@example.org',
+            password: '1234',
+          },
+        )
+        authenticatedUser = await admin.toJson()
+      })
+
+      it('is permitted', async () => {
+        await expect(query({ query: userQuery, variables })).resolves.toMatchObject({
+          data: { User: [{ name: 'Johnny' }] },
+          errors: undefined,
+        })
+      })
+
+      it('non-existing email address, issue #2294', async () => {
+        // see: https://github.com/Human-Connection/Human-Connection/issues/2294
+        await expect(
+          query({
+            query: userQuery,
+            variables: {
+              email: 'this-email-does-not-exist@example.org',
+            },
+          }),
+        ).resolves.toMatchObject({
+          data: { User: [] },
+          errors: undefined,
+        })
+      })
+    })
+  })
 })
-
-
-
-
 
 describe('Delete a User as admin', () => {
+  beforeEach(async () => {
+    variables = { id: ' u343', resource: [] }
 
-    beforeEach(async() => {
-        variables = { id: ' u343', resource: [] }
+    user = await Factory.build('user', {
+      name: 'My name should be deleted',
+      about: 'along with my about',
+      id: 'u343',
+    })
+  })
 
-        user = await Factory.build('user', {
-            name: 'My name should be deleted',
-            about: 'along with my about',
-            id: 'u343',
-        })
+  describe('authenticated as Admin', () => {
+    beforeEach(async () => {
+      admin = await Factory.build(
+        'user',
+        {
+          role: 'admin',
+        },
+        {
+          email: 'admin@example.org',
+          password: '1234',
+        },
+      )
+      authenticatedUser = await admin.toJson()
     })
 
-    describe('authenticated as Admin', () => {
-        beforeEach(async() => {
-            admin = await Factory.build(
-                'user', {
-                    role: 'admin',
-                }, {
-                    email: 'admin@example.org',
-                    password: '1234',
+    describe('deleting a user account', () => {
+      beforeEach(() => {
+        variables = { ...variables, id: 'u343' }
+      })
+
+      describe('given posts and comments', () => {
+        beforeEach(async () => {
+          await Factory.build('category', {
+            id: 'cat9',
+            name: 'Democracy & Politics',
+            icon: 'university',
+          })
+          await Factory.build(
+            'post',
+            {
+              id: 'p139',
+              content: 'Post by user u343',
+            },
+            {
+              author: user,
+              categoryIds,
+            },
+          )
+          await Factory.build(
+            'comment',
+            {
+              id: 'c155',
+              content: 'Comment by user u343',
+            },
+            {
+              author: user,
+            },
+          )
+          await Factory.build(
+            'comment',
+            {
+              id: 'c156',
+              content: "A comment by someone else on user u343's post",
+            },
+            {
+              postId: 'p139',
+            },
+          )
+        })
+
+        it("deletes account, but doesn't delete posts or comments by default", async () => {
+          const expectedResponse = {
+            data: {
+              DeleteUser: {
+                id: 'u343',
+                name: 'UNAVAILABLE',
+                about: 'UNAVAILABLE',
+                deleted: true,
+                contributions: [
+                  {
+                    id: 'p139',
+                    content: 'Post by user u343',
+                    contentExcerpt: 'Post by user u343',
+                    deleted: false,
+                    comments: [
+                      {
+                        id: 'c156',
+                        content: "A comment by someone else on user u343's post",
+                        contentExcerpt: "A comment by someone else on user u343's post",
+                        deleted: false,
+                      },
+                    ],
+                  },
+                ],
+                comments: [
+                  {
+                    id: 'c155',
+                    content: 'Comment by user u343',
+                    contentExcerpt: 'Comment by user u343',
+                    deleted: false,
+                  },
+                ],
+              },
+            },
+            errors: undefined,
+          }
+          await expect(mutate({ mutation: deleteUserMutation, variables })).resolves.toMatchObject(
+            expectedResponse,
+          )
+        })
+
+        describe('deletion of all post requested', () => {
+          beforeEach(() => {
+            variables = { ...variables, resource: ['Post'] }
+          })
+
+          it('on request', async () => {
+            const expectedResponse = {
+              data: {
+                DeleteUser: {
+                  id: 'u343',
+                  name: 'UNAVAILABLE',
+                  about: 'UNAVAILABLE',
+                  deleted: true,
+                  contributions: [
+                    {
+                      id: 'p139',
+                      content: 'UNAVAILABLE',
+                      contentExcerpt: 'UNAVAILABLE',
+                      deleted: true,
+                      comments: [
+                        {
+                          id: 'c156',
+                          content: 'UNAVAILABLE',
+                          contentExcerpt: 'UNAVAILABLE',
+                          deleted: true,
+                        },
+                      ],
+                    },
+                  ],
+                  comments: [
+                    {
+                      id: 'c155',
+                      content: 'Comment by user u343',
+                      contentExcerpt: 'Comment by user u343',
+                      deleted: false,
+                    },
+                  ],
                 },
-            )
-            authenticatedUser = await admin.toJson()
+              },
+              errors: undefined,
+            }
+            await expect(
+              mutate({ mutation: deleteUserMutation, variables }),
+            ).resolves.toMatchObject(expectedResponse)
+          })
+
+          it('deletes user avatar and post hero images', async () => {
+            await expect(neode.all('Image')).resolves.toHaveLength(22)
+            await mutate({ mutation: deleteUserMutation, variables })
+            await expect(neode.all('Image')).resolves.toHaveLength(20)
+          })
         })
 
-        describe('deleting a user account', () => {
-            beforeEach(() => {
-                variables = {...variables, id: 'u343' }
-            })
+        describe('deletion of all comments requested', () => {
+          beforeEach(() => {
+            variables = { ...variables, resource: ['Comment'] }
+          })
 
-            describe('given posts and comments', () => {
-                beforeEach(async() => {
-                    await Factory.build('category', {
-                        id: 'cat9',
-                        name: 'Democracy & Politics',
-                        icon: 'university',
-                    })
-                    await Factory.build(
-                        'post', {
-                            id: 'p139',
-                            content: 'Post by user u343',
-                        }, {
-                            author: user,
-                            categoryIds,
+          it('marks comments as deleted', async () => {
+            const expectedResponse = {
+              data: {
+                DeleteUser: {
+                  id: 'u343',
+                  name: 'UNAVAILABLE',
+                  about: 'UNAVAILABLE',
+                  deleted: true,
+                  contributions: [
+                    {
+                      id: 'p139',
+                      content: 'Post by user u343',
+                      contentExcerpt: 'Post by user u343',
+                      deleted: false,
+                      comments: [
+                        {
+                          id: 'c156',
+                          content: "A comment by someone else on user u343's post",
+                          contentExcerpt: "A comment by someone else on user u343's post",
+                          deleted: false,
                         },
-                    )
-                    await Factory.build(
-                        'comment', {
-                            id: 'c155',
-                            content: 'Comment by user u343',
-                        }, {
-                            author: user,
-                        },
-                    )
-                    await Factory.build(
-                        'comment', {
-                            id: 'c156',
-                            content: "A comment by someone else on user u343's post",
-                        }, {
-                            postId: 'p139',
-                        },
-                    )
-                })
-
-                it("deletes account, but doesn't delete posts or comments by default", async() => {
-                    const expectedResponse = {
-                        data: {
-                            DeleteUser: {
-                                id: 'u343',
-                                name: 'UNAVAILABLE',
-                                about: 'UNAVAILABLE',
-                                deleted: true,
-                                contributions: [{
-                                    id: 'p139',
-                                    content: 'Post by user u343',
-                                    contentExcerpt: 'Post by user u343',
-                                    deleted: false,
-                                    comments: [{
-                                        id: 'c156',
-                                        content: "A comment by someone else on user u343's post",
-                                        contentExcerpt: "A comment by someone else on user u343's post",
-                                        deleted: false,
-                                    }, ],
-                                }, ],
-                                comments: [{
-                                    id: 'c155',
-                                    content: 'Comment by user u343',
-                                    contentExcerpt: 'Comment by user u343',
-                                    deleted: false,
-                                }, ],
-                            },
-                        },
-                        errors: undefined,
-                    }
-                    await expect(
-                        mutate({ mutation: deleteUserMutation, variables }),
-                    ).resolves.toMatchObject(expectedResponse)
-                })
-
-                describe('deletion of all post requested', () => {
-
-                    beforeEach(() => {
-                        variables = {...variables, resource: ['Post'] }
-                    })
-
-
-                    it('on request', async() => {
-                        const expectedResponse = {
-                            data: {
-                                DeleteUser: {
-                                    id: 'u343',
-                                    name: 'UNAVAILABLE',
-                                    about: 'UNAVAILABLE',
-                                    deleted: true,
-                                    contributions: [{
-                                        id: 'p139',
-                                        content: 'UNAVAILABLE',
-                                        contentExcerpt: 'UNAVAILABLE',
-                                        deleted: true,
-                                        comments: [{
-                                            id: 'c156',
-                                            content: 'UNAVAILABLE',
-                                            contentExcerpt: 'UNAVAILABLE',
-                                            deleted: true,
-                                        }, ],
-                                    }, ],
-                                    comments: [{
-                                        id: 'c155',
-                                        content: 'Comment by user u343',
-                                        contentExcerpt: 'Comment by user u343',
-                                        deleted: false,
-                                    }, ],
-                                },
-                            },
-                            errors: undefined,
-                        }
-                        await expect(
-                            mutate({ mutation: deleteUserMutation, variables }),
-                        ).resolves.toMatchObject(expectedResponse)
-                    })
-
-                    it('deletes user avatar and post hero images', async() => {
-                        await expect(neode.all('Image')).resolves.toHaveLength(22)
-                        await mutate({ mutation: deleteUserMutation, variables })
-                        await expect(neode.all('Image')).resolves.toHaveLength(20)
-                    })
-
-                })
-
-                describe('deletion of all comments requested', () => {
-                    beforeEach(() => {
-                        variables = {...variables, resource: ['Comment'] }
-                    })
-
-
-                    it('marks comments as deleted', async() => {
-                        const expectedResponse = {
-                            data: {
-                                DeleteUser: {
-                                    id: 'u343',
-                                    name: 'UNAVAILABLE',
-                                    about: 'UNAVAILABLE',
-                                    deleted: true,
-                                    contributions: [{
-                                        id: 'p139',
-                                        content: 'Post by user u343',
-                                        contentExcerpt: 'Post by user u343',
-                                        deleted: false,
-                                        comments: [{
-                                            id: 'c156',
-                                            content: "A comment by someone else on user u343's post",
-                                            contentExcerpt: "A comment by someone else on user u343's post",
-                                            deleted: false,
-                                        }, ],
-                                    }, ],
-                                    comments: [{
-                                        id: 'c155',
-                                        content: 'UNAVAILABLE',
-                                        contentExcerpt: 'UNAVAILABLE',
-                                        deleted: true,
-                                    }, ],
-                                },
-                            },
-                            errors: undefined,
-                        }
-                        await expect(
-                            mutate({ mutation: deleteUserMutation, variables }),
-                        ).resolves.toMatchObject(expectedResponse)
-                    })
-
-
-
-                })
-
-                describe('deletion of all posts and comments requested', () => {
-                    beforeEach(() => {
-                        variables = {...variables,
-                            resource: ['Comment', 'Post']
-                        }
-                    })
-
-                    it('marks posts and comments as deleted', async() => {
-                        const expectedResponse = {
-                            data: {
-                                DeleteUser: {
-                                    id: 'u343',
-                                    name: 'UNAVAILABLE',
-                                    about: 'UNAVAILABLE',
-                                    deleted: true,
-                                    contributions: [{
-                                        id: 'p139',
-                                        content: 'UNAVAILABLE',
-                                        contentExcerpt: 'UNAVAILABLE',
-                                        deleted: true,
-                                        comments: [{
-                                            id: 'c156',
-                                            content: 'UNAVAILABLE',
-                                            contentExcerpt: 'UNAVAILABLE',
-                                            deleted: true,
-                                        }, ],
-                                    }, ],
-                                    comments: [{
-                                        id: 'c155',
-                                        content: 'UNAVAILABLE',
-                                        contentExcerpt: 'UNAVAILABLE',
-                                        deleted: true,
-                                    }, ],
-                                },
-                            },
-                            errors: undefined,
-                        }
-                        await expect(
-                            mutate({ mutation: deleteUserMutation, variables }),
-                        ).resolves.toMatchObject(expectedResponse)
-                    })
-                })
-            })
-
-            describe('connected `EmailAddress` nodes', () => {
-                it('will be removed completely', async() => {
-                    await expect(neode.all('EmailAddress')).resolves.toHaveLength(2)
-                    await mutate({ mutation: deleteUserMutation, variables })
-
-                    await expect(neode.all('EmailAddress')).resolves.toHaveLength(1)
-                })
-            })
-
-            describe('connected `SocialMedia` nodes', () => {
-                beforeEach(async() => {
-                    const socialMedia = await Factory.build('socialMedia')
-                    await socialMedia.relateTo(user, 'ownedBy')
-                })
-
-                it('will be removed completely', async() => {
-                    await expect(neode.all('SocialMedia')).resolves.toHaveLength(1)
-                    await mutate({ mutation: deleteUserMutation, variables })
-                    await expect(neode.all('SocialMedia')).resolves.toHaveLength(0)
-                })
-            })
+                      ],
+                    },
+                  ],
+                  comments: [
+                    {
+                      id: 'c155',
+                      content: 'UNAVAILABLE',
+                      contentExcerpt: 'UNAVAILABLE',
+                      deleted: true,
+                    },
+                  ],
+                },
+              },
+              errors: undefined,
+            }
+            await expect(
+              mutate({ mutation: deleteUserMutation, variables }),
+            ).resolves.toMatchObject(expectedResponse)
+          })
         })
+
+        describe('deletion of all posts and comments requested', () => {
+          beforeEach(() => {
+            variables = { ...variables, resource: ['Comment', 'Post'] }
+          })
+
+          it('marks posts and comments as deleted', async () => {
+            const expectedResponse = {
+              data: {
+                DeleteUser: {
+                  id: 'u343',
+                  name: 'UNAVAILABLE',
+                  about: 'UNAVAILABLE',
+                  deleted: true,
+                  contributions: [
+                    {
+                      id: 'p139',
+                      content: 'UNAVAILABLE',
+                      contentExcerpt: 'UNAVAILABLE',
+                      deleted: true,
+                      comments: [
+                        {
+                          id: 'c156',
+                          content: 'UNAVAILABLE',
+                          contentExcerpt: 'UNAVAILABLE',
+                          deleted: true,
+                        },
+                      ],
+                    },
+                  ],
+                  comments: [
+                    {
+                      id: 'c155',
+                      content: 'UNAVAILABLE',
+                      contentExcerpt: 'UNAVAILABLE',
+                      deleted: true,
+                    },
+                  ],
+                },
+              },
+              errors: undefined,
+            }
+            await expect(
+              mutate({ mutation: deleteUserMutation, variables }),
+            ).resolves.toMatchObject(expectedResponse)
+          })
+        })
+      })
+
+      describe('connected `EmailAddress` nodes', () => {
+        it('will be removed completely', async () => {
+          await expect(neode.all('EmailAddress')).resolves.toHaveLength(2)
+          await mutate({ mutation: deleteUserMutation, variables })
+
+          await expect(neode.all('EmailAddress')).resolves.toHaveLength(1)
+        })
+      })
+
+      describe('connected `SocialMedia` nodes', () => {
+        beforeEach(async () => {
+          const socialMedia = await Factory.build('socialMedia')
+          await socialMedia.relateTo(user, 'ownedBy')
+        })
+
+        it('will be removed completely', async () => {
+          await expect(neode.all('SocialMedia')).resolves.toHaveLength(1)
+          await mutate({ mutation: deleteUserMutation, variables })
+          await expect(neode.all('SocialMedia')).resolves.toHaveLength(0)
+        })
+      })
     })
-
-
-
+  })
 })
 
-
-
-
-
 describe('UpdateUser', () => {
-    let variables
+  let variables
 
-    beforeEach(async() => {
-        variables = {
-            id: 'u47',
-            name: 'John Doughnut',
-        }
-    })
+  beforeEach(async () => {
+    variables = {
+      id: 'u47',
+      name: 'John Doughnut',
+    }
+  })
 
-    const updateUserMutation = gql `
+  const updateUserMutation = gql`
     mutation(
       $id: ID!
       $name: String
@@ -499,116 +507,120 @@ describe('UpdateUser', () => {
     }
   `
 
-    beforeEach(async() => {
-        user = await Factory.build(
-            'user', {
-                id: 'u47',
-                name: 'John Doe',
-                termsAndConditionsAgreedVersion: null,
-                termsAndConditionsAgreedAt: null,
-                allowEmbedIframes: false,
-            }, {
-                email: 'user@example.org',
-            },
+  beforeEach(async () => {
+    user = await Factory.build(
+      'user',
+      {
+        id: 'u47',
+        name: 'John Doe',
+        termsAndConditionsAgreedVersion: null,
+        termsAndConditionsAgreedAt: null,
+        allowEmbedIframes: false,
+      },
+      {
+        email: 'user@example.org',
+      },
+    )
+  })
+
+  describe('as another user', () => {
+    beforeEach(async () => {
+      const someoneElse = await Factory.build(
+        'user',
+        {
+          name: 'James Doe',
+        },
+        {
+          email: 'someone-else@example.org',
+        },
+      )
+
+      authenticatedUser = await someoneElse.toJson()
+    })
+
+    it('is not allowed to change other user accounts', async () => {
+      const { errors } = await mutate({ mutation: updateUserMutation, variables })
+      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+    })
+  })
+
+  describe('as the same user', () => {
+    beforeEach(async () => {
+      authenticatedUser = await user.toJson()
+    })
+
+    it('updates the name', async () => {
+      const expected = {
+        data: {
+          UpdateUser: {
+            id: 'u47',
+            name: 'John Doughnut',
+          },
+        },
+        errors: undefined,
+      }
+      await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
+        expected,
+      )
+    })
+
+    describe('given a new agreed version of terms and conditions', () => {
+      beforeEach(async () => {
+        variables = { ...variables, termsAndConditionsAgreedVersion: '0.0.2' }
+      })
+      it('update termsAndConditionsAgreedVersion', async () => {
+        const expected = {
+          data: {
+            UpdateUser: expect.objectContaining({
+              termsAndConditionsAgreedVersion: '0.0.2',
+              termsAndConditionsAgreedAt: expect.any(String),
+            }),
+          },
+          errors: undefined,
+        }
+
+        await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
+          expected,
         )
+      })
     })
 
-    describe('as another user', () => {
-        beforeEach(async() => {
-            const someoneElse = await Factory.build(
-                'user', {
-                    name: 'James Doe',
-                }, {
-                    email: 'someone-else@example.org',
-                },
-            )
+    describe('given any attribute other than termsAndConditionsAgreedVersion', () => {
+      beforeEach(async () => {
+        variables = { ...variables, name: 'any name' }
+      })
+      it('update termsAndConditionsAgreedVersion', async () => {
+        const expected = {
+          data: {
+            UpdateUser: expect.objectContaining({
+              termsAndConditionsAgreedVersion: null,
+              termsAndConditionsAgreedAt: null,
+            }),
+          },
+          errors: undefined,
+        }
 
-            authenticatedUser = await someoneElse.toJson()
-        })
-
-        it('is not allowed to change other user accounts', async() => {
-            const { errors } = await mutate({ mutation: updateUserMutation, variables })
-            expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-        })
+        await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
+          expected,
+        )
+      })
     })
 
-    describe('as the same user', () => {
-        beforeEach(async() => {
-            authenticatedUser = await user.toJson()
-        })
-
-        it('updates the name', async() => {
-            const expected = {
-                data: {
-                    UpdateUser: {
-                        id: 'u47',
-                        name: 'John Doughnut',
-                    },
-                },
-                errors: undefined,
-            }
-            await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
-                expected,
-            )
-        })
-
-        describe('given a new agreed version of terms and conditions', () => {
-            beforeEach(async() => {
-                variables = {...variables, termsAndConditionsAgreedVersion: '0.0.2' }
-            })
-            it('update termsAndConditionsAgreedVersion', async() => {
-                const expected = {
-                    data: {
-                        UpdateUser: expect.objectContaining({
-                            termsAndConditionsAgreedVersion: '0.0.2',
-                            termsAndConditionsAgreedAt: expect.any(String),
-                        }),
-                    },
-                    errors: undefined,
-                }
-
-                await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
-                    expected,
-                )
-            })
-        })
-
-        describe('given any attribute other than termsAndConditionsAgreedVersion', () => {
-            beforeEach(async() => {
-                variables = {...variables, name: 'any name' }
-            })
-            it('update termsAndConditionsAgreedVersion', async() => {
-                const expected = {
-                    data: {
-                        UpdateUser: expect.objectContaining({
-                            termsAndConditionsAgreedVersion: null,
-                            termsAndConditionsAgreedAt: null,
-                        }),
-                    },
-                    errors: undefined,
-                }
-
-                await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
-                    expected,
-                )
-            })
-        })
-
-        it('rejects if version of terms and conditions has wrong format', async() => {
-            variables = {
-                ...variables,
-                termsAndConditionsAgreedVersion: 'invalid version format',
-            }
-            const { errors } = await mutate({ mutation: updateUserMutation, variables })
-            expect(errors[0]).toHaveProperty('message', 'Invalid version format!')
-        })
-
-        it('supports updating location', async() => {
-            variables = {...variables, locationName: 'Hamburg, New Jersey, United States of America' }
-            await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject({
-                data: { UpdateUser: { locationName: 'Hamburg, New Jersey, United States of America' } },
-                errors: undefined,
-            })
-        })
+    it('rejects if version of terms and conditions has wrong format', async () => {
+      variables = {
+        ...variables,
+        termsAndConditionsAgreedVersion: 'invalid version format',
+      }
+      const { errors } = await mutate({ mutation: updateUserMutation, variables })
+      expect(errors[0]).toHaveProperty('message', 'Invalid version format!')
     })
+
+    it('supports updating location', async () => {
+      variables = { ...variables, locationName: 'Hamburg, New Jersey, United States of America' }
+      await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject({
+        data: { UpdateUser: { locationName: 'Hamburg, New Jersey, United States of America' } },
+        errors: undefined,
+      })
+    })
+  })
 })

--- a/backend/src/schema/resolvers/users.spec.js
+++ b/backend/src/schema/resolvers/users.spec.js
@@ -18,7 +18,7 @@ let variables
 const driver = getDriver()
 const neode = getNeode()
 
-const deleteUserMutation = gql`
+const deleteUserMutation = gql `
   mutation($id: ID!, $resource: [Deletable]) {
     DeleteUser(id: $id, resource: $resource) {
       id
@@ -48,579 +48,517 @@ const deleteUserMutation = gql`
 `
 
 beforeAll(() => {
-  const { server } = createServer({
-    context: () => {
-      return {
-        driver,
-        neode,
-        user: authenticatedUser,
-      }
-    },
-  })
-  query = createTestClient(server).query
-  mutate = createTestClient(server).mutate
-})
-
-beforeEach(async () => {
-  await cleanDatabase()
-})
-
-describe('Delete a User as another user', () => {
-  beforeEach(async () => {
-    variables = { id: ' u343', resource: [] }
-
-    user = await Factory.build('user', {
-      name: 'My name should be deleted',
-      about: 'along with my about',
-      id: 'u343',
+    const { server } = createServer({
+        context: () => {
+            return {
+                driver,
+                neode,
+                user: authenticatedUser,
+            }
+        },
     })
-  })
-
-  beforeEach(async () => {
-    anotherUser = await Factory.build(
-      'user',
-      {
-        role: 'user',
-      },
-      {
-        email: 'user@example.org',
-        password: '1234',
-      },
-    )
-
-    authenticatedUser = await anotherUser.toJson()
-  })
-
-  it("an ordinary user has no authorization to delete another user's account", async () => {
-    const { errors } = await mutate({ mutation: deleteUserMutation, variables })
-    expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-  })
+    query = createTestClient(server).query
+    mutate = createTestClient(server).mutate
 })
 
-describe('Delete a User as moderator', () => {
-  beforeEach(async () => {
-    variables = { id: ' u343', resource: [] }
-
-    user = await Factory.build('user', {
-      name: 'My name should be deleted',
-      about: 'along with my about',
-      id: 'u343',
-    })
-  })
-
-  beforeEach(async () => {
-    moderator = await Factory.build(
-      'user',
-      {
-        role: 'moderator',
-      },
-      {
-        email: 'moderator@example.org',
-        password: '1234',
-      },
-    )
-
-    authenticatedUser = await moderator.toJson()
-  })
-
-  it('moderator is not allowed to delete other user accounts', async () => {
-    const { errors } = await mutate({ mutation: deleteUserMutation, variables })
-    expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-  })
+beforeEach(async() => {
+    await cleanDatabase()
 })
+
 
 describe('User', () => {
-  describe('query by email address', () => {
-    beforeEach(async () => {
-      await Factory.build('user', { name: 'Johnny' }, { email: 'any-email-address@example.org' })
+    describe('query by email address', () => {
+        beforeEach(async() => {
+            await Factory.build('user', { name: 'Johnny' }, { email: 'any-email-address@example.org' })
+        })
+
+        const userQuery = gql `query($email: String) { User(email: $email) {  name      }    }`
+        const variables = { email: 'any-email-address@example.org' }
+
+        it('is forbidden', async() => {
+            await expect(query({ query: userQuery, variables })).resolves.toMatchObject({
+                errors: [{ message: 'Not Authorised!' }],
+            })
+        })
+
+        describe('as admin', () => {
+            beforeEach(async() => {
+                const admin = await Factory.build(
+                    'user', {
+                        role: 'admin',
+                    }, {
+                        email: 'admin@example.org',
+                        password: '1234',
+                    },
+                )
+                authenticatedUser = await admin.toJson()
+            })
+
+            it('is permitted', async() => {
+                await expect(query({ query: userQuery, variables })).resolves.toMatchObject({
+                    data: { User: [{ name: 'Johnny' }] },
+                    errors: undefined,
+                })
+            })
+
+            it('non-existing email address, issue #2294', async() => {
+                // see: https://github.com/Human-Connection/Human-Connection/issues/2294
+                await expect(
+                    query({
+                        query: userQuery,
+                        variables: {
+                            email: 'this-email-does-not-exist@example.org',
+                        },
+                    }),
+                ).resolves.toMatchObject({
+                    data: { User: [] },
+                    errors: undefined,
+                })
+            })
+        })
+    })
+})
+
+
+
+describe('UpdateUser', () => {
+    let variables
+
+    beforeEach(async() => {
+        variables = {
+            id: 'u47',
+            name: 'John Doughnut',
+        }
     })
 
-    const userQuery = gql`
-      query($email: String) {
-        User(email: $email) {
-          name
-        }
-      }
-    `
-    const variables = { email: 'any-email-address@example.org' }
+    const updateUserMutation = gql `
+  mutation(
+    $id: ID!
+    $name: String
+    $termsAndConditionsAgreedVersion: String
+    $locationName: String
+  ) {
+    UpdateUser(
+      id: $id
+      name: $name
+      termsAndConditionsAgreedVersion: $termsAndConditionsAgreedVersion
+      locationName: $locationName
+    ) {
+      id
+      name
+      termsAndConditionsAgreedVersion
+      termsAndConditionsAgreedAt
+      locationName
+    }
+  }
+`
+    beforeEach(async() => {
+        user = await Factory.build(
+            'user', {
+                id: 'u47',
+                name: 'John Doe',
+                termsAndConditionsAgreedVersion: null,
+                termsAndConditionsAgreedAt: null,
+                allowEmbedIframes: false,
+            }, {
+                email: 'user@example.org',
+            },
+        )
+    })
 
-    it('is forbidden', async () => {
-      await expect(query({ query: userQuery, variables })).resolves.toMatchObject({
-        errors: [{ message: 'Not Authorised!' }],
-      })
+    describe('as another user', () => {
+        beforeEach(async() => {
+            const someoneElse = await Factory.build(
+                'user', {
+                    name: 'James Doe',
+                }, {
+                    email: 'someone-else@example.org',
+                },
+            )
+
+            authenticatedUser = await someoneElse.toJson()
+        })
+
+        it('is not allowed to change other user accounts', async() => {
+            const { errors } = await mutate({ mutation: updateUserMutation, variables })
+            expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+        })
+    })
+
+    describe('as the same user', () => {
+        beforeEach(async() => {
+            authenticatedUser = await user.toJson()
+        })
+
+        it('updates the name', async() => {
+            const expected = {
+                data: {
+                    UpdateUser: {
+                        id: 'u47',
+                        name: 'John Doughnut',
+                    },
+                },
+                errors: undefined,
+            }
+            await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
+                expected,
+            )
+        })
+
+        describe('given a new agreed version of terms and conditions', () => {
+            beforeEach(async() => {
+                variables = {...variables, termsAndConditionsAgreedVersion: '0.0.2' }
+            })
+            it('update termsAndConditionsAgreedVersion', async() => {
+                const expected = {
+                    data: {
+                        UpdateUser: expect.objectContaining({
+                            termsAndConditionsAgreedVersion: '0.0.2',
+                            termsAndConditionsAgreedAt: expect.any(String),
+                        }),
+                    },
+                    errors: undefined,
+                }
+
+                await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
+                    expected,
+                )
+            })
+        })
+
+        describe('given any attribute other than termsAndConditionsAgreedVersion', () => {
+            beforeEach(async() => {
+                variables = {...variables, name: 'any name' }
+            })
+            it('update termsAndConditionsAgreedVersion', async() => {
+                const expected = {
+                    data: {
+                        UpdateUser: expect.objectContaining({
+                            termsAndConditionsAgreedVersion: null,
+                            termsAndConditionsAgreedAt: null,
+                        }),
+                    },
+                    errors: undefined,
+                }
+
+                await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
+                    expected,
+                )
+            })
+        })
+
+        it('rejects if version of terms and conditions has wrong format', async() => {
+            variables = {
+                ...variables,
+                termsAndConditionsAgreedVersion: 'invalid version format',
+            }
+            const { errors } = await mutate({ mutation: updateUserMutation, variables })
+            expect(errors[0]).toHaveProperty('message', 'Invalid version format!')
+        })
+
+        it('supports updating location', async() => {
+            variables = {...variables, locationName: 'Hamburg, New Jersey, United States of America' }
+            await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject({
+                data: { UpdateUser: { locationName: 'Hamburg, New Jersey, United States of America' } },
+                errors: undefined,
+            })
+        })
+    })
+})
+
+describe('Delete a user', () => {
+    beforeEach(async() => {
+        variables = { id: ' u343', resource: [] }
+
+        user = await Factory.build('user', {
+            name: 'My name should be deleted',
+            about: 'along with my about',
+            id: 'u343',
+        })
+    })
+
+    describe('as another user', () => {
+        beforeEach(async() => {
+
+            anotherUser = await Factory.build(
+                'user', {
+                    role: 'user',
+                }, {
+                    email: 'user@example.org',
+                    password: '1234',
+                },
+            )
+
+            authenticatedUser = await anotherUser.toJson()
+        })
+
+        it("an ordinary user has no authorization to delete another user's account", async() => {
+            const { errors } = await mutate({ mutation: deleteUserMutation, variables })
+            expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+        })
+    })
+
+    describe('as moderator', () => {
+        beforeEach(async() => {
+
+            moderator = await Factory.build(
+                'user', {
+                    role: 'moderator',
+                }, {
+                    email: 'moderator@example.org',
+                    password: '1234',
+                },
+            )
+
+            authenticatedUser = await moderator.toJson()
+        })
+
+        it('moderator is not allowed to delete other user accounts', async() => {
+            const { errors } = await mutate({ mutation: deleteUserMutation, variables })
+            expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+        })
     })
 
     describe('as admin', () => {
-      beforeEach(async () => {
-        const admin = await Factory.build(
-          'user',
-          {
-            role: 'admin',
-          },
-          {
-            email: 'admin@example.org',
-            password: '1234',
-          },
-        )
-        authenticatedUser = await admin.toJson()
-      })
-
-      it('is permitted', async () => {
-        await expect(query({ query: userQuery, variables })).resolves.toMatchObject({
-          data: { User: [{ name: 'Johnny' }] },
-          errors: undefined,
-        })
-      })
-
-      it('non-existing email address, issue #2294', async () => {
-        // see: https://github.com/Human-Connection/Human-Connection/issues/2294
-        await expect(
-          query({
-            query: userQuery,
-            variables: {
-              email: 'this-email-does-not-exist@example.org',
-            },
-          }),
-        ).resolves.toMatchObject({
-          data: { User: [] },
-          errors: undefined,
-        })
-      })
-    })
-  })
-})
-
-describe('Delete a User as admin', () => {
-  beforeEach(async () => {
-    variables = { id: ' u343', resource: [] }
-
-    user = await Factory.build('user', {
-      name: 'My name should be deleted',
-      about: 'along with my about',
-      id: 'u343',
-    })
-  })
-
-  describe('authenticated as Admin', () => {
-    beforeEach(async () => {
-      admin = await Factory.build(
-        'user',
-        {
-          role: 'admin',
-        },
-        {
-          email: 'admin@example.org',
-          password: '1234',
-        },
-      )
-      authenticatedUser = await admin.toJson()
-    })
-
-    describe('deleting a user account', () => {
-      beforeEach(() => {
-        variables = { ...variables, id: 'u343' }
-      })
-
-      describe('given posts and comments', () => {
-        beforeEach(async () => {
-          await Factory.build('category', {
-            id: 'cat9',
-            name: 'Democracy & Politics',
-            icon: 'university',
-          })
-          await Factory.build(
-            'post',
-            {
-              id: 'p139',
-              content: 'Post by user u343',
-            },
-            {
-              author: user,
-              categoryIds,
-            },
-          )
-          await Factory.build(
-            'comment',
-            {
-              id: 'c155',
-              content: 'Comment by user u343',
-            },
-            {
-              author: user,
-            },
-          )
-          await Factory.build(
-            'comment',
-            {
-              id: 'c156',
-              content: "A comment by someone else on user u343's post",
-            },
-            {
-              postId: 'p139',
-            },
-          )
-        })
-
-        it("deletes account, but doesn't delete posts or comments by default", async () => {
-          const expectedResponse = {
-            data: {
-              DeleteUser: {
-                id: 'u343',
-                name: 'UNAVAILABLE',
-                about: 'UNAVAILABLE',
-                deleted: true,
-                contributions: [
-                  {
-                    id: 'p139',
-                    content: 'Post by user u343',
-                    contentExcerpt: 'Post by user u343',
-                    deleted: false,
-                    comments: [
-                      {
-                        id: 'c156',
-                        content: "A comment by someone else on user u343's post",
-                        contentExcerpt: "A comment by someone else on user u343's post",
-                        deleted: false,
-                      },
-                    ],
-                  },
-                ],
-                comments: [
-                  {
-                    id: 'c155',
-                    content: 'Comment by user u343',
-                    contentExcerpt: 'Comment by user u343',
-                    deleted: false,
-                  },
-                ],
-              },
-            },
-            errors: undefined,
-          }
-          await expect(mutate({ mutation: deleteUserMutation, variables })).resolves.toMatchObject(
-            expectedResponse,
-          )
-        })
-
-        describe('deletion of all post requested', () => {
-          beforeEach(() => {
-            variables = { ...variables, resource: ['Post'] }
-          })
-
-          it('on request', async () => {
-            const expectedResponse = {
-              data: {
-                DeleteUser: {
-                  id: 'u343',
-                  name: 'UNAVAILABLE',
-                  about: 'UNAVAILABLE',
-                  deleted: true,
-                  contributions: [
-                    {
-                      id: 'p139',
-                      content: 'UNAVAILABLE',
-                      contentExcerpt: 'UNAVAILABLE',
-                      deleted: true,
-                      comments: [
-                        {
-                          id: 'c156',
-                          content: 'UNAVAILABLE',
-                          contentExcerpt: 'UNAVAILABLE',
-                          deleted: true,
-                        },
-                      ],
+        describe('authenticated as Admin', () => {
+            beforeEach(async() => {
+                admin = await Factory.build(
+                    'user', {
+                        role: 'admin',
+                    }, {
+                        email: 'admin@example.org',
+                        password: '1234',
                     },
-                  ],
-                  comments: [
-                    {
-                      id: 'c155',
-                      content: 'Comment by user u343',
-                      contentExcerpt: 'Comment by user u343',
-                      deleted: false,
-                    },
-                  ],
-                },
-              },
-              errors: undefined,
-            }
-            await expect(
-              mutate({ mutation: deleteUserMutation, variables }),
-            ).resolves.toMatchObject(expectedResponse)
-          })
+                )
+                authenticatedUser = await admin.toJson()
+            })
 
-          it('deletes user avatar and post hero images', async () => {
-            await expect(neode.all('Image')).resolves.toHaveLength(22)
-            await mutate({ mutation: deleteUserMutation, variables })
-            await expect(neode.all('Image')).resolves.toHaveLength(20)
-          })
+            describe('deleting a user account', () => {
+                beforeEach(() => {
+                    variables = {...variables, id: 'u343' }
+                })
+
+                describe('given posts and comments', () => {
+                    beforeEach(async() => {
+                        await Factory.build('category', {
+                            id: 'cat9',
+                            name: 'Democracy & Politics',
+                            icon: 'university',
+                        })
+                        await Factory.build(
+                            'post', {
+                                id: 'p139',
+                                content: 'Post by user u343',
+                            }, {
+                                author: user,
+                                categoryIds,
+                            },
+                        )
+                        await Factory.build(
+                            'comment', {
+                                id: 'c155',
+                                content: 'Comment by user u343',
+                            }, {
+                                author: user,
+                            },
+                        )
+                        await Factory.build(
+                            'comment', {
+                                id: 'c156',
+                                content: "A comment by someone else on user u343's post",
+                            }, {
+                                postId: 'p139',
+                            },
+                        )
+                    })
+
+                    it("deletes account, but doesn't delete posts or comments by default", async() => {
+                        const expectedResponse = {
+                            data: {
+                                DeleteUser: {
+                                    id: 'u343',
+                                    name: 'UNAVAILABLE',
+                                    about: 'UNAVAILABLE',
+                                    deleted: true,
+                                    contributions: [{
+                                        id: 'p139',
+                                        content: 'Post by user u343',
+                                        contentExcerpt: 'Post by user u343',
+                                        deleted: false,
+                                        comments: [{
+                                            id: 'c156',
+                                            content: "A comment by someone else on user u343's post",
+                                            contentExcerpt: "A comment by someone else on user u343's post",
+                                            deleted: false,
+                                        }, ],
+                                    }, ],
+                                    comments: [{
+                                        id: 'c155',
+                                        content: 'Comment by user u343',
+                                        contentExcerpt: 'Comment by user u343',
+                                        deleted: false,
+                                    }, ],
+                                },
+                            },
+                            errors: undefined,
+                        }
+                        await expect(mutate({ mutation: deleteUserMutation, variables })).resolves.toMatchObject(
+                            expectedResponse,
+                        )
+                    })
+
+                    describe('deletion of all post requested', () => {
+                        beforeEach(() => {
+                            variables = {...variables, resource: ['Post'] }
+                        })
+
+                        it('on request', async() => {
+                            const expectedResponse = {
+                                data: {
+                                    DeleteUser: {
+                                        id: 'u343',
+                                        name: 'UNAVAILABLE',
+                                        about: 'UNAVAILABLE',
+                                        deleted: true,
+                                        contributions: [{
+                                            id: 'p139',
+                                            content: 'UNAVAILABLE',
+                                            contentExcerpt: 'UNAVAILABLE',
+                                            deleted: true,
+                                            comments: [{
+                                                id: 'c156',
+                                                content: 'UNAVAILABLE',
+                                                contentExcerpt: 'UNAVAILABLE',
+                                                deleted: true,
+                                            }, ],
+                                        }, ],
+                                        comments: [{
+                                            id: 'c155',
+                                            content: 'Comment by user u343',
+                                            contentExcerpt: 'Comment by user u343',
+                                            deleted: false,
+                                        }, ],
+                                    },
+                                },
+                                errors: undefined,
+                            }
+                            await expect(
+                                mutate({ mutation: deleteUserMutation, variables }),
+                            ).resolves.toMatchObject(expectedResponse)
+                        })
+
+                        it('deletes user avatar and post hero images', async() => {
+                            await expect(neode.all('Image')).resolves.toHaveLength(22)
+                            await mutate({ mutation: deleteUserMutation, variables })
+                            await expect(neode.all('Image')).resolves.toHaveLength(20)
+                        })
+                    })
+
+                    describe('deletion of all comments requested', () => {
+                        beforeEach(() => {
+                            variables = {...variables, resource: ['Comment'] }
+                        })
+
+                        it('marks comments as deleted', async() => {
+                            const expectedResponse = {
+                                data: {
+                                    DeleteUser: {
+                                        id: 'u343',
+                                        name: 'UNAVAILABLE',
+                                        about: 'UNAVAILABLE',
+                                        deleted: true,
+                                        contributions: [{
+                                            id: 'p139',
+                                            content: 'Post by user u343',
+                                            contentExcerpt: 'Post by user u343',
+                                            deleted: false,
+                                            comments: [{
+                                                id: 'c156',
+                                                content: "A comment by someone else on user u343's post",
+                                                contentExcerpt: "A comment by someone else on user u343's post",
+                                                deleted: false,
+                                            }, ],
+                                        }, ],
+                                        comments: [{
+                                            id: 'c155',
+                                            content: 'UNAVAILABLE',
+                                            contentExcerpt: 'UNAVAILABLE',
+                                            deleted: true,
+                                        }, ],
+                                    },
+                                },
+                                errors: undefined,
+                            }
+                            await expect(
+                                mutate({ mutation: deleteUserMutation, variables }),
+                            ).resolves.toMatchObject(expectedResponse)
+                        })
+                    })
+
+                    describe('deletion of all posts and comments requested', () => {
+                        beforeEach(() => {
+                            variables = {...variables, resource: ['Comment', 'Post'] }
+                        })
+
+                        it('marks posts and comments as deleted', async() => {
+                            const expectedResponse = {
+                                data: {
+                                    DeleteUser: {
+                                        id: 'u343',
+                                        name: 'UNAVAILABLE',
+                                        about: 'UNAVAILABLE',
+                                        deleted: true,
+                                        contributions: [{
+                                            id: 'p139',
+                                            content: 'UNAVAILABLE',
+                                            contentExcerpt: 'UNAVAILABLE',
+                                            deleted: true,
+                                            comments: [{
+                                                id: 'c156',
+                                                content: 'UNAVAILABLE',
+                                                contentExcerpt: 'UNAVAILABLE',
+                                                deleted: true,
+                                            }, ],
+                                        }, ],
+                                        comments: [{
+                                            id: 'c155',
+                                            content: 'UNAVAILABLE',
+                                            contentExcerpt: 'UNAVAILABLE',
+                                            deleted: true,
+                                        }, ],
+                                    },
+                                },
+                                errors: undefined,
+                            }
+                            await expect(
+                                mutate({ mutation: deleteUserMutation, variables }),
+                            ).resolves.toMatchObject(expectedResponse)
+                        })
+                    })
+                })
+
+                describe('connected `EmailAddress` nodes', () => {
+                    it('will be removed completely', async() => {
+                        await expect(neode.all('EmailAddress')).resolves.toHaveLength(2)
+                        await mutate({ mutation: deleteUserMutation, variables })
+
+                        await expect(neode.all('EmailAddress')).resolves.toHaveLength(1)
+                    })
+                })
+
+                describe('connected `SocialMedia` nodes', () => {
+                    beforeEach(async() => {
+                        const socialMedia = await Factory.build('socialMedia')
+                        await socialMedia.relateTo(user, 'ownedBy')
+                    })
+
+                    it('will be removed completely', async() => {
+                        await expect(neode.all('SocialMedia')).resolves.toHaveLength(1)
+                        await mutate({ mutation: deleteUserMutation, variables })
+                        await expect(neode.all('SocialMedia')).resolves.toHaveLength(0)
+                    })
+                })
+            })
         })
-
-        describe('deletion of all comments requested', () => {
-          beforeEach(() => {
-            variables = { ...variables, resource: ['Comment'] }
-          })
-
-          it('marks comments as deleted', async () => {
-            const expectedResponse = {
-              data: {
-                DeleteUser: {
-                  id: 'u343',
-                  name: 'UNAVAILABLE',
-                  about: 'UNAVAILABLE',
-                  deleted: true,
-                  contributions: [
-                    {
-                      id: 'p139',
-                      content: 'Post by user u343',
-                      contentExcerpt: 'Post by user u343',
-                      deleted: false,
-                      comments: [
-                        {
-                          id: 'c156',
-                          content: "A comment by someone else on user u343's post",
-                          contentExcerpt: "A comment by someone else on user u343's post",
-                          deleted: false,
-                        },
-                      ],
-                    },
-                  ],
-                  comments: [
-                    {
-                      id: 'c155',
-                      content: 'UNAVAILABLE',
-                      contentExcerpt: 'UNAVAILABLE',
-                      deleted: true,
-                    },
-                  ],
-                },
-              },
-              errors: undefined,
-            }
-            await expect(
-              mutate({ mutation: deleteUserMutation, variables }),
-            ).resolves.toMatchObject(expectedResponse)
-          })
-        })
-
-        describe('deletion of all posts and comments requested', () => {
-          beforeEach(() => {
-            variables = { ...variables, resource: ['Comment', 'Post'] }
-          })
-
-          it('marks posts and comments as deleted', async () => {
-            const expectedResponse = {
-              data: {
-                DeleteUser: {
-                  id: 'u343',
-                  name: 'UNAVAILABLE',
-                  about: 'UNAVAILABLE',
-                  deleted: true,
-                  contributions: [
-                    {
-                      id: 'p139',
-                      content: 'UNAVAILABLE',
-                      contentExcerpt: 'UNAVAILABLE',
-                      deleted: true,
-                      comments: [
-                        {
-                          id: 'c156',
-                          content: 'UNAVAILABLE',
-                          contentExcerpt: 'UNAVAILABLE',
-                          deleted: true,
-                        },
-                      ],
-                    },
-                  ],
-                  comments: [
-                    {
-                      id: 'c155',
-                      content: 'UNAVAILABLE',
-                      contentExcerpt: 'UNAVAILABLE',
-                      deleted: true,
-                    },
-                  ],
-                },
-              },
-              errors: undefined,
-            }
-            await expect(
-              mutate({ mutation: deleteUserMutation, variables }),
-            ).resolves.toMatchObject(expectedResponse)
-          })
-        })
-      })
-
-      describe('connected `EmailAddress` nodes', () => {
-        it('will be removed completely', async () => {
-          await expect(neode.all('EmailAddress')).resolves.toHaveLength(2)
-          await mutate({ mutation: deleteUserMutation, variables })
-
-          await expect(neode.all('EmailAddress')).resolves.toHaveLength(1)
-        })
-      })
-
-      describe('connected `SocialMedia` nodes', () => {
-        beforeEach(async () => {
-          const socialMedia = await Factory.build('socialMedia')
-          await socialMedia.relateTo(user, 'ownedBy')
-        })
-
-        it('will be removed completely', async () => {
-          await expect(neode.all('SocialMedia')).resolves.toHaveLength(1)
-          await mutate({ mutation: deleteUserMutation, variables })
-          await expect(neode.all('SocialMedia')).resolves.toHaveLength(0)
-        })
-      })
     })
-  })
-})
-
-describe('UpdateUser', () => {
-  let variables
-
-  beforeEach(async () => {
-    variables = {
-      id: 'u47',
-      name: 'John Doughnut',
-    }
-  })
-
-  const updateUserMutation = gql`
-    mutation(
-      $id: ID!
-      $name: String
-      $termsAndConditionsAgreedVersion: String
-      $locationName: String
-    ) {
-      UpdateUser(
-        id: $id
-        name: $name
-        termsAndConditionsAgreedVersion: $termsAndConditionsAgreedVersion
-        locationName: $locationName
-      ) {
-        id
-        name
-        termsAndConditionsAgreedVersion
-        termsAndConditionsAgreedAt
-        locationName
-      }
-    }
-  `
-
-  beforeEach(async () => {
-    user = await Factory.build(
-      'user',
-      {
-        id: 'u47',
-        name: 'John Doe',
-        termsAndConditionsAgreedVersion: null,
-        termsAndConditionsAgreedAt: null,
-        allowEmbedIframes: false,
-      },
-      {
-        email: 'user@example.org',
-      },
-    )
-  })
-
-  describe('as another user', () => {
-    beforeEach(async () => {
-      const someoneElse = await Factory.build(
-        'user',
-        {
-          name: 'James Doe',
-        },
-        {
-          email: 'someone-else@example.org',
-        },
-      )
-
-      authenticatedUser = await someoneElse.toJson()
-    })
-
-    it('is not allowed to change other user accounts', async () => {
-      const { errors } = await mutate({ mutation: updateUserMutation, variables })
-      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-    })
-  })
-
-  describe('as the same user', () => {
-    beforeEach(async () => {
-      authenticatedUser = await user.toJson()
-    })
-
-    it('updates the name', async () => {
-      const expected = {
-        data: {
-          UpdateUser: {
-            id: 'u47',
-            name: 'John Doughnut',
-          },
-        },
-        errors: undefined,
-      }
-      await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
-        expected,
-      )
-    })
-
-    describe('given a new agreed version of terms and conditions', () => {
-      beforeEach(async () => {
-        variables = { ...variables, termsAndConditionsAgreedVersion: '0.0.2' }
-      })
-      it('update termsAndConditionsAgreedVersion', async () => {
-        const expected = {
-          data: {
-            UpdateUser: expect.objectContaining({
-              termsAndConditionsAgreedVersion: '0.0.2',
-              termsAndConditionsAgreedAt: expect.any(String),
-            }),
-          },
-          errors: undefined,
-        }
-
-        await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
-          expected,
-        )
-      })
-    })
-
-    describe('given any attribute other than termsAndConditionsAgreedVersion', () => {
-      beforeEach(async () => {
-        variables = { ...variables, name: 'any name' }
-      })
-      it('update termsAndConditionsAgreedVersion', async () => {
-        const expected = {
-          data: {
-            UpdateUser: expect.objectContaining({
-              termsAndConditionsAgreedVersion: null,
-              termsAndConditionsAgreedAt: null,
-            }),
-          },
-          errors: undefined,
-        }
-
-        await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject(
-          expected,
-        )
-      })
-    })
-
-    it('rejects if version of terms and conditions has wrong format', async () => {
-      variables = {
-        ...variables,
-        termsAndConditionsAgreedVersion: 'invalid version format',
-      }
-      const { errors } = await mutate({ mutation: updateUserMutation, variables })
-      expect(errors[0]).toHaveProperty('message', 'Invalid version format!')
-    })
-
-    it('supports updating location', async () => {
-      variables = { ...variables, locationName: 'Hamburg, New Jersey, United States of America' }
-      await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject({
-        data: { UpdateUser: { locationName: 'Hamburg, New Jersey, United States of America' } },
-        errors: undefined,
-      })
-    })
-  })
 })

--- a/webapp/components/DeleteData/DeleteData.spec.js
+++ b/webapp/components/DeleteData/DeleteData.spec.js
@@ -69,11 +69,11 @@ describe('DeleteData.vue', () => {
     })
 
     it('defaults to deleteContributions to true', () => {
-      expect(wrapper.vm.deleteContributions).toEqual(true)
+      expect(wrapper.vm.deleteContributions).toEqual(false)
     })
 
     it('defaults to deleteComments to true', () => {
-      expect(wrapper.vm.deleteComments).toEqual(true)
+      expect(wrapper.vm.deleteComments).toEqual(false)
     })
 
     it('defaults to deleteEnabled to false', () => {
@@ -93,29 +93,11 @@ describe('DeleteData.vue', () => {
         deleteAccountBtn = wrapper.find('[data-test="delete-button"]')
       })
 
-      it("deletes user's posts and comments if requested by default", () => {
-        mocks.$t.mockImplementation(() => deleteContributionsMessage)
-        enableContributionDeletionCheckbox = wrapper.findAll('input[type="checkbox"]').at(0)
-        mocks.$t.mockImplementation(() => deleteCommentsMessage)
-        enableCommentDeletionCheckbox = wrapper.findAll('input[type="checkbox"]').at(1)
-        deleteAccountBtn.trigger('click')
-        expect(mocks.$apollo.mutate).toHaveBeenCalledWith(
-          expect.objectContaining({
-            variables: {
-              id: 'u343',
-              resource: ['Post', 'Comment'],
-            },
-          }),
-        )
-      })
-
       it('if deleteEnabled is true and only deletes user ', () => {
         mocks.$t.mockImplementation(() => deleteContributionsMessage)
         enableContributionDeletionCheckbox = wrapper.findAll('input[type="checkbox"]').at(0)
-        enableContributionDeletionCheckbox.trigger('click')
         mocks.$t.mockImplementation(() => deleteCommentsMessage)
         enableCommentDeletionCheckbox = wrapper.findAll('input[type="checkbox"]').at(1)
-        enableCommentDeletionCheckbox.trigger('click')
         deleteAccountBtn.trigger('click')
         expect(mocks.$apollo.mutate).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -127,9 +109,27 @@ describe('DeleteData.vue', () => {
         )
       })
 
+      it("deletes user's posts and comments if requested by default ", () => {
+        mocks.$t.mockImplementation(() => deleteContributionsMessage)
+        enableContributionDeletionCheckbox = wrapper.findAll('input[type="checkbox"]').at(0)
+        enableContributionDeletionCheckbox.trigger('click')
+        mocks.$t.mockImplementation(() => deleteCommentsMessage)
+        enableCommentDeletionCheckbox = wrapper.findAll('input[type="checkbox"]').at(1)
+        enableCommentDeletionCheckbox.trigger('click')
+        deleteAccountBtn.trigger('click')
+        expect(mocks.$apollo.mutate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variables: {
+              id: 'u343',
+              resource: ['Post', 'Comment'],
+            },
+          }),
+        )
+      })
+
       it("deletes a user's posts if requested", () => {
         mocks.$t.mockImplementation(() => deleteContributionsMessage)
-        enableContributionDeletionCheckbox = wrapper.findAll('input[type="checkbox"]').at(1)
+        enableContributionDeletionCheckbox = wrapper.findAll('input[type="checkbox"]').at(0)
         enableContributionDeletionCheckbox.trigger('click')
         deleteAccountBtn.trigger('click')
         expect(mocks.$apollo.mutate).toHaveBeenCalledWith(
@@ -144,7 +144,7 @@ describe('DeleteData.vue', () => {
 
       it("deletes a user's comments if requested", () => {
         mocks.$t.mockImplementation(() => deleteCommentsMessage)
-        enableCommentDeletionCheckbox = wrapper.findAll('input[type="checkbox"]').at(0)
+        enableCommentDeletionCheckbox = wrapper.findAll('input[type="checkbox"]').at(1)
         enableCommentDeletionCheckbox.trigger('click')
         deleteAccountBtn.trigger('click')
         expect(mocks.$apollo.mutate).toHaveBeenCalledWith(

--- a/webapp/components/DeleteData/DeleteData.spec.js
+++ b/webapp/components/DeleteData/DeleteData.spec.js
@@ -45,7 +45,7 @@ describe('DeleteData.vue', () => {
     }
     getters = {
       'auth/user': () => {
-        return { id: 'u343', name: deleteAccountName, contributionsCount: 2, commentedCount: 3 }
+        return { id: 'u343', name: deleteAccountName }
       },
     }
     actions = { 'auth/logout': jest.fn() }

--- a/webapp/components/DeleteData/DeleteData.spec.js
+++ b/webapp/components/DeleteData/DeleteData.spec.js
@@ -6,180 +6,172 @@ import Vuex from 'vuex'
 const localVue = global.localVue
 
 describe('DeleteData.vue', () => {
-  let mocks
-  let wrapper
-  let getters
-  let actions
-  let deleteAccountBtn
-  let enableDeletionInput
-  let enableContributionDeletionCheckbox
-  let enableCommentDeletionCheckbox
-  const deleteAccountName = 'Delete MyAccount'
-  const deleteContributionsMessage = 'Delete my 2 posts'
-  const deleteCommentsMessage = 'Delete my 3 comments'
-
-  beforeEach(() => {
-    mocks = {
-      $t: jest.fn(),
-      $apollo: {
-        mutate: jest
-          .fn()
-          .mockResolvedValueOnce({
-            data: {
-              DeleteData: {
-                id: 'u343',
-              },
-            },
-          })
-          .mockRejectedValue({ message: 'Not authorised!' }),
-      },
-      $toast: {
-        error: jest.fn(),
-        success: jest.fn(),
-      },
-      $router: {
-        history: {
-          push: jest.fn(),
-        },
-      },
-    }
-    getters = {
-      'auth/user': () => {
-        return { id: 'u343', name: deleteAccountName }
-      },
-    }
-    actions = { 'auth/logout': jest.fn() }
-  })
-
-  describe('mount', () => {
-    const Wrapper = () => {
-      const store = new Vuex.Store({
-        getters,
-        actions,
-      })
-      return mount(DeleteData, { mocks, localVue, store })
-    }
+    let mocks
+    let wrapper
+    let getters
+    let actions
+    let deleteAccountBtn
+    let enableDeletionInput
+    let enableContributionDeletionCheckbox
+    let enableCommentDeletionCheckbox
+    const deleteAccountName = 'Delete MyAccount'
+    const deleteContributionsMessage = 'Delete my 2 posts'
+    const deleteCommentsMessage = 'Delete my 3 comments'
 
     beforeEach(() => {
-      wrapper = Wrapper()
-    })
-
-    afterEach(() => {
-      jest.clearAllMocks()
-    })
-
-    it('defaults to deleteContributions to true', () => {
-      expect(wrapper.vm.deleteContributions).toEqual(false)
-    })
-
-    it('defaults to deleteComments to true', () => {
-      expect(wrapper.vm.deleteComments).toEqual(false)
-    })
-
-    it('defaults to deleteEnabled to false', () => {
-      expect(wrapper.vm.deleteEnabled).toEqual(false)
-    })
-
-    it('does not call the delete user mutation if deleteEnabled is false', () => {
-      deleteAccountBtn = wrapper.find('[data-test="delete-button"]')
-      deleteAccountBtn.trigger('click')
-      expect(mocks.$apollo.mutate).not.toHaveBeenCalled()
-    })
-
-    describe('calls the delete user mutation', () => {
-      beforeEach(() => {
-        enableDeletionInput = wrapper.find('.ds-input')
-        enableDeletionInput.setValue(deleteAccountName)
-        deleteAccountBtn = wrapper.find('[data-test="delete-button"]')
-      })
-
-      it('if deleteEnabled is true and only deletes user ', () => {
-        mocks.$t.mockImplementation(() => deleteContributionsMessage)
-        enableContributionDeletionCheckbox = wrapper.findAll('input[type="checkbox"]').at(0)
-        mocks.$t.mockImplementation(() => deleteCommentsMessage)
-        enableCommentDeletionCheckbox = wrapper.findAll('input[type="checkbox"]').at(1)
-        deleteAccountBtn.trigger('click')
-        expect(mocks.$apollo.mutate).toHaveBeenCalledWith(
-          expect.objectContaining({
-            variables: {
-              id: 'u343',
-              resource: [],
+        mocks = {
+            $t: jest.fn((a) => a),
+            $apollo: {
+                mutate: jest
+                    .fn()
+                    .mockResolvedValueOnce({
+                        data: {
+                            DeleteData: {
+                                id: 'u343',
+                            },
+                        },
+                    })
+                    .mockRejectedValue({ message: 'Not authorised!' }),
             },
-          }),
-        )
-      })
-
-      it("deletes user's posts and comments if requested by default ", () => {
-        mocks.$t.mockImplementation(() => deleteContributionsMessage)
-        enableContributionDeletionCheckbox = wrapper.findAll('input[type="checkbox"]').at(0)
-        enableContributionDeletionCheckbox.trigger('click')
-        mocks.$t.mockImplementation(() => deleteCommentsMessage)
-        enableCommentDeletionCheckbox = wrapper.findAll('input[type="checkbox"]').at(1)
-        enableCommentDeletionCheckbox.trigger('click')
-        deleteAccountBtn.trigger('click')
-        expect(mocks.$apollo.mutate).toHaveBeenCalledWith(
-          expect.objectContaining({
-            variables: {
-              id: 'u343',
-              resource: ['Post', 'Comment'],
+            $toast: {
+                error: jest.fn(),
+                success: jest.fn(),
             },
-          }),
-        )
-      })
-
-      it("deletes a user's posts if requested", () => {
-        mocks.$t.mockImplementation(() => deleteContributionsMessage)
-        enableContributionDeletionCheckbox = wrapper.findAll('input[type="checkbox"]').at(0)
-        enableContributionDeletionCheckbox.trigger('click')
-        deleteAccountBtn.trigger('click')
-        expect(mocks.$apollo.mutate).toHaveBeenCalledWith(
-          expect.objectContaining({
-            variables: {
-              id: 'u343',
-              resource: ['Post'],
+            $router: {
+                history: {
+                    push: jest.fn(),
+                },
             },
-          }),
-        )
-      })
-
-      it("deletes a user's comments if requested", () => {
-        mocks.$t.mockImplementation(() => deleteCommentsMessage)
-        enableCommentDeletionCheckbox = wrapper.findAll('input[type="checkbox"]').at(1)
-        enableCommentDeletionCheckbox.trigger('click')
-        deleteAccountBtn.trigger('click')
-        expect(mocks.$apollo.mutate).toHaveBeenCalledWith(
-          expect.objectContaining({
-            variables: {
-              id: 'u343',
-              resource: ['Comment'],
+        }
+        getters = {
+            'auth/user': () => {
+                return { id: 'u343', name: deleteAccountName }
             },
-          }),
-        )
-      })
-
-      it('shows a success toaster after successful mutation', async () => {
-        await deleteAccountBtn.trigger('click')
-        expect(mocks.$toast.success).toHaveBeenCalledTimes(1)
-      })
-
-      it('redirect the user to the homepage', async () => {
-        await deleteAccountBtn.trigger('click')
-        expect(mocks.$router.history.push).toHaveBeenCalledWith('/')
-      })
+        }
+        actions = { 'auth/logout': jest.fn() }
     })
 
-    describe('error handling', () => {
-      it('shows an error toaster when the mutation rejects', async () => {
-        enableDeletionInput = wrapper.find('.ds-input')
-        enableDeletionInput.setValue(deleteAccountName)
-        await Vue.nextTick()
-        deleteAccountBtn = wrapper.find('[data-test="delete-button"]')
-        await deleteAccountBtn.trigger('click')
-        // second submission causes mutation to reject
-        await deleteAccountBtn.trigger('click')
-        await mocks.$apollo.mutate
-        expect(mocks.$toast.error).toHaveBeenCalledWith('Not authorised!')
-      })
+    describe('mount', () => {
+        const Wrapper = () => {
+            const store = new Vuex.Store({
+                getters,
+                actions,
+            })
+            return mount(DeleteData, { mocks, localVue, store })
+        }
+
+        beforeEach(() => {
+            wrapper = Wrapper()
+        })
+
+        afterEach(() => {
+            jest.clearAllMocks()
+        })
+
+        it('checkbox deleteContributions defaults be false', () => {
+            expect(wrapper.vm.deleteContributions).toEqual(false)
+        })
+
+        it('checkbox deleteComments defaults be false', () => {
+            expect(wrapper.vm.deleteComments).toEqual(false)
+        })
+
+        it('deleteButton defaults be false', () => {
+            expect(wrapper.vm.deleteEnabled).toEqual(false)
+        })
+
+        it('does not call the delete user mutation if deleteEnabled is false', () => {
+            deleteAccountBtn = wrapper.find('[data-test="delete-button"]')
+            deleteAccountBtn.trigger('click')
+            expect(mocks.$apollo.mutate).not.toHaveBeenCalled()
+        })
+
+        describe('calls the delete user mutation', () => {
+            beforeEach(() => {
+                enableDeletionInput = wrapper.find('.ds-input')
+                enableDeletionInput.setValue(deleteAccountName)
+                deleteAccountBtn = wrapper.find('[data-test="delete-button"]')
+            })
+
+            it('if deleteEnabled is true and only deletes user ', () => {
+                deleteAccountBtn.trigger('click')
+                expect(mocks.$apollo.mutate).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        variables: {
+                            id: 'u343',
+                            resource: [],
+                        },
+                    }),
+                )
+            })
+
+            it("deletes user's posts and comments if requested by default ", () => {
+                enableContributionDeletionCheckbox = wrapper.find('[data-test="contributions-deletion-checkbox"]')
+                enableContributionDeletionCheckbox.trigger('click')
+                enableCommentDeletionCheckbox = wrapper.find('[data-test="comments-deletion-checkbox"]')
+                enableCommentDeletionCheckbox.trigger('click')
+                deleteAccountBtn.trigger('click')
+                expect(mocks.$apollo.mutate).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        variables: {
+                            id: 'u343',
+                            resource: ['Post', 'Comment'],
+                        },
+                    }),
+                )
+            })
+
+            it("deletes a user's posts if requested", () => {
+                enableContributionDeletionCheckbox = wrapper.find('[data-test="contributions-deletion-checkbox"]')
+                enableContributionDeletionCheckbox.trigger('click')
+                deleteAccountBtn.trigger('click')
+                expect(mocks.$apollo.mutate).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        variables: {
+                            id: 'u343',
+                            resource: ['Post'],
+                        },
+                    }),
+                )
+            })
+
+            it("deletes a user's comments if requested", () => {
+                enableCommentDeletionCheckbox = wrapper.find('[data-test="comments-deletion-checkbox"]')
+                enableCommentDeletionCheckbox.trigger('click')
+                deleteAccountBtn.trigger('click')
+                expect(mocks.$apollo.mutate).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        variables: {
+                            id: 'u343',
+                            resource: ['Comment'],
+                        },
+                    }),
+                )
+            })
+
+            it('shows a success toaster after successful mutation', async() => {
+                await deleteAccountBtn.trigger('click')
+                expect(mocks.$toast.success).toHaveBeenCalledTimes(1)
+            })
+
+            it('redirect the user to the homepage', async() => {
+                await deleteAccountBtn.trigger('click')
+                expect(mocks.$router.history.push).toHaveBeenCalledWith('/')
+            })
+        })
+
+        describe('error handling', () => {
+            it('shows an error toaster when the mutation rejects', async() => {
+                enableDeletionInput = wrapper.find('.ds-input')
+                enableDeletionInput.setValue(deleteAccountName)
+                await Vue.nextTick()
+                deleteAccountBtn = wrapper.find('[data-test="delete-button"]')
+                await deleteAccountBtn.trigger('click')
+                    // second submission causes mutation to reject
+                await deleteAccountBtn.trigger('click')
+                await mocks.$apollo.mutate
+                expect(mocks.$toast.error).toHaveBeenCalledWith('Not authorised!')
+            })
+        })
     })
-  })
 })

--- a/webapp/components/DeleteData/DeleteData.spec.js
+++ b/webapp/components/DeleteData/DeleteData.spec.js
@@ -93,7 +93,6 @@ describe('DeleteData.vue', () => {
         deleteAccountBtn = wrapper.find('[data-test="delete-button"]')
       })
 
-
       it("deletes user's posts and comments if requested by default", () => {
         mocks.$t.mockImplementation(() => deleteContributionsMessage)
         enableContributionDeletionCheckbox = wrapper.findAll('input[type="checkbox"]').at(0)
@@ -109,7 +108,6 @@ describe('DeleteData.vue', () => {
           }),
         )
       })
-
 
       it('if deleteEnabled is true and only deletes user ', () => {
         mocks.$t.mockImplementation(() => deleteContributionsMessage)
@@ -158,8 +156,6 @@ describe('DeleteData.vue', () => {
           }),
         )
       })
-
- 
 
       it('shows a success toaster after successful mutation', async () => {
         await deleteAccountBtn.trigger('click')

--- a/webapp/components/DeleteData/DeleteData.spec.js
+++ b/webapp/components/DeleteData/DeleteData.spec.js
@@ -6,172 +6,174 @@ import Vuex from 'vuex'
 const localVue = global.localVue
 
 describe('DeleteData.vue', () => {
-    let mocks
-    let wrapper
-    let getters
-    let actions
-    let deleteAccountBtn
-    let enableDeletionInput
-    let enableContributionDeletionCheckbox
-    let enableCommentDeletionCheckbox
-    const deleteAccountName = 'Delete MyAccount'
-    const deleteContributionsMessage = 'Delete my 2 posts'
-    const deleteCommentsMessage = 'Delete my 3 comments'
+  let mocks
+  let wrapper
+  let getters
+  let actions
+  let deleteAccountBtn
+  let enableDeletionInput
+  let enableContributionDeletionCheckbox
+  let enableCommentDeletionCheckbox
+  const deleteAccountName = 'Delete MyAccount'
+
+  beforeEach(() => {
+    mocks = {
+      $t: jest.fn((a) => a),
+      $apollo: {
+        mutate: jest
+          .fn()
+          .mockResolvedValueOnce({
+            data: {
+              DeleteData: {
+                id: 'u343',
+              },
+            },
+          })
+          .mockRejectedValue({ message: 'Not authorised!' }),
+      },
+      $toast: {
+        error: jest.fn(),
+        success: jest.fn(),
+      },
+      $router: {
+        history: {
+          push: jest.fn(),
+        },
+      },
+    }
+    getters = {
+      'auth/user': () => {
+        return { id: 'u343', name: deleteAccountName }
+      },
+    }
+    actions = { 'auth/logout': jest.fn() }
+  })
+
+  describe('mount', () => {
+    const Wrapper = () => {
+      const store = new Vuex.Store({
+        getters,
+        actions,
+      })
+      return mount(DeleteData, { mocks, localVue, store })
+    }
 
     beforeEach(() => {
-        mocks = {
-            $t: jest.fn((a) => a),
-            $apollo: {
-                mutate: jest
-                    .fn()
-                    .mockResolvedValueOnce({
-                        data: {
-                            DeleteData: {
-                                id: 'u343',
-                            },
-                        },
-                    })
-                    .mockRejectedValue({ message: 'Not authorised!' }),
-            },
-            $toast: {
-                error: jest.fn(),
-                success: jest.fn(),
-            },
-            $router: {
-                history: {
-                    push: jest.fn(),
-                },
-            },
-        }
-        getters = {
-            'auth/user': () => {
-                return { id: 'u343', name: deleteAccountName }
-            },
-        }
-        actions = { 'auth/logout': jest.fn() }
+      wrapper = Wrapper()
     })
 
-    describe('mount', () => {
-        const Wrapper = () => {
-            const store = new Vuex.Store({
-                getters,
-                actions,
-            })
-            return mount(DeleteData, { mocks, localVue, store })
-        }
-
-        beforeEach(() => {
-            wrapper = Wrapper()
-        })
-
-        afterEach(() => {
-            jest.clearAllMocks()
-        })
-
-        it('checkbox deleteContributions defaults be false', () => {
-            expect(wrapper.vm.deleteContributions).toEqual(false)
-        })
-
-        it('checkbox deleteComments defaults be false', () => {
-            expect(wrapper.vm.deleteComments).toEqual(false)
-        })
-
-        it('deleteButton defaults be false', () => {
-            expect(wrapper.vm.deleteEnabled).toEqual(false)
-        })
-
-        it('does not call the delete user mutation if deleteEnabled is false', () => {
-            deleteAccountBtn = wrapper.find('[data-test="delete-button"]')
-            deleteAccountBtn.trigger('click')
-            expect(mocks.$apollo.mutate).not.toHaveBeenCalled()
-        })
-
-        describe('calls the delete user mutation', () => {
-            beforeEach(() => {
-                enableDeletionInput = wrapper.find('.ds-input')
-                enableDeletionInput.setValue(deleteAccountName)
-                deleteAccountBtn = wrapper.find('[data-test="delete-button"]')
-            })
-
-            it('if deleteEnabled is true and only deletes user ', () => {
-                deleteAccountBtn.trigger('click')
-                expect(mocks.$apollo.mutate).toHaveBeenCalledWith(
-                    expect.objectContaining({
-                        variables: {
-                            id: 'u343',
-                            resource: [],
-                        },
-                    }),
-                )
-            })
-
-            it("deletes user's posts and comments if requested by default ", () => {
-                enableContributionDeletionCheckbox = wrapper.find('[data-test="contributions-deletion-checkbox"]')
-                enableContributionDeletionCheckbox.trigger('click')
-                enableCommentDeletionCheckbox = wrapper.find('[data-test="comments-deletion-checkbox"]')
-                enableCommentDeletionCheckbox.trigger('click')
-                deleteAccountBtn.trigger('click')
-                expect(mocks.$apollo.mutate).toHaveBeenCalledWith(
-                    expect.objectContaining({
-                        variables: {
-                            id: 'u343',
-                            resource: ['Post', 'Comment'],
-                        },
-                    }),
-                )
-            })
-
-            it("deletes a user's posts if requested", () => {
-                enableContributionDeletionCheckbox = wrapper.find('[data-test="contributions-deletion-checkbox"]')
-                enableContributionDeletionCheckbox.trigger('click')
-                deleteAccountBtn.trigger('click')
-                expect(mocks.$apollo.mutate).toHaveBeenCalledWith(
-                    expect.objectContaining({
-                        variables: {
-                            id: 'u343',
-                            resource: ['Post'],
-                        },
-                    }),
-                )
-            })
-
-            it("deletes a user's comments if requested", () => {
-                enableCommentDeletionCheckbox = wrapper.find('[data-test="comments-deletion-checkbox"]')
-                enableCommentDeletionCheckbox.trigger('click')
-                deleteAccountBtn.trigger('click')
-                expect(mocks.$apollo.mutate).toHaveBeenCalledWith(
-                    expect.objectContaining({
-                        variables: {
-                            id: 'u343',
-                            resource: ['Comment'],
-                        },
-                    }),
-                )
-            })
-
-            it('shows a success toaster after successful mutation', async() => {
-                await deleteAccountBtn.trigger('click')
-                expect(mocks.$toast.success).toHaveBeenCalledTimes(1)
-            })
-
-            it('redirect the user to the homepage', async() => {
-                await deleteAccountBtn.trigger('click')
-                expect(mocks.$router.history.push).toHaveBeenCalledWith('/')
-            })
-        })
-
-        describe('error handling', () => {
-            it('shows an error toaster when the mutation rejects', async() => {
-                enableDeletionInput = wrapper.find('.ds-input')
-                enableDeletionInput.setValue(deleteAccountName)
-                await Vue.nextTick()
-                deleteAccountBtn = wrapper.find('[data-test="delete-button"]')
-                await deleteAccountBtn.trigger('click')
-                    // second submission causes mutation to reject
-                await deleteAccountBtn.trigger('click')
-                await mocks.$apollo.mutate
-                expect(mocks.$toast.error).toHaveBeenCalledWith('Not authorised!')
-            })
-        })
+    afterEach(() => {
+      jest.clearAllMocks()
     })
+
+    it('checkbox deleteContributions defaults be false', () => {
+      expect(wrapper.vm.deleteContributions).toEqual(false)
+    })
+
+    it('checkbox deleteComments defaults be false', () => {
+      expect(wrapper.vm.deleteComments).toEqual(false)
+    })
+
+    it('deleteButton defaults be false', () => {
+      expect(wrapper.vm.deleteEnabled).toEqual(false)
+    })
+
+    it('does not call the delete user mutation if deleteEnabled is false', () => {
+      deleteAccountBtn = wrapper.find('[data-test="delete-button"]')
+      deleteAccountBtn.trigger('click')
+      expect(mocks.$apollo.mutate).not.toHaveBeenCalled()
+    })
+
+    describe('calls the delete user mutation', () => {
+      beforeEach(() => {
+        enableDeletionInput = wrapper.find('.ds-input')
+        enableDeletionInput.setValue(deleteAccountName)
+        deleteAccountBtn = wrapper.find('[data-test="delete-button"]')
+      })
+
+      it('if deleteEnabled is true and only deletes user ', () => {
+        deleteAccountBtn.trigger('click')
+        expect(mocks.$apollo.mutate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variables: {
+              id: 'u343',
+              resource: [],
+            },
+          }),
+        )
+      })
+
+      it("deletes user's posts and comments if requested by default ", () => {
+        enableContributionDeletionCheckbox = wrapper.find(
+          '[data-test="contributions-deletion-checkbox"]',
+        )
+        enableContributionDeletionCheckbox.trigger('click')
+        enableCommentDeletionCheckbox = wrapper.find('[data-test="comments-deletion-checkbox"]')
+        enableCommentDeletionCheckbox.trigger('click')
+        deleteAccountBtn.trigger('click')
+        expect(mocks.$apollo.mutate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variables: {
+              id: 'u343',
+              resource: ['Post', 'Comment'],
+            },
+          }),
+        )
+      })
+
+      it("deletes a user's posts if requested", () => {
+        enableContributionDeletionCheckbox = wrapper.find(
+          '[data-test="contributions-deletion-checkbox"]',
+        )
+        enableContributionDeletionCheckbox.trigger('click')
+        deleteAccountBtn.trigger('click')
+        expect(mocks.$apollo.mutate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variables: {
+              id: 'u343',
+              resource: ['Post'],
+            },
+          }),
+        )
+      })
+
+      it("deletes a user's comments if requested", () => {
+        enableCommentDeletionCheckbox = wrapper.find('[data-test="comments-deletion-checkbox"]')
+        enableCommentDeletionCheckbox.trigger('click')
+        deleteAccountBtn.trigger('click')
+        expect(mocks.$apollo.mutate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variables: {
+              id: 'u343',
+              resource: ['Comment'],
+            },
+          }),
+        )
+      })
+
+      it('shows a success toaster after successful mutation', async () => {
+        await deleteAccountBtn.trigger('click')
+        expect(mocks.$toast.success).toHaveBeenCalledTimes(1)
+      })
+
+      it('redirect the user to the homepage', async () => {
+        await deleteAccountBtn.trigger('click')
+        expect(mocks.$router.history.push).toHaveBeenCalledWith('/')
+      })
+    })
+
+    describe('error handling', () => {
+      it('shows an error toaster when the mutation rejects', async () => {
+        enableDeletionInput = wrapper.find('.ds-input')
+        enableDeletionInput.setValue(deleteAccountName)
+        await Vue.nextTick()
+        deleteAccountBtn = wrapper.find('[data-test="delete-button"]')
+        await deleteAccountBtn.trigger('click')
+        // second submission causes mutation to reject
+        await deleteAccountBtn.trigger('click')
+        await mocks.$apollo.mutate
+        expect(mocks.$toast.error).toHaveBeenCalledWith('Not authorised!')
+      })
+    })
+  })
 })

--- a/webapp/components/DeleteData/DeleteData.vue
+++ b/webapp/components/DeleteData/DeleteData.vue
@@ -1,5 +1,5 @@
 <template>
-  <base-card v-if="currentUser.role !== 'admin'" class="delete-data">
+  <base-card class="delete-data">
     <h2 class="title">
       <base-icon name="warning" />
       {{ $t('settings.deleteUserAccount.name') }}
@@ -46,9 +46,6 @@
     >
       {{ $t('settings.deleteUserAccount.name') }}
     </base-button>
-  </base-card>
-  <base-card v-else class="delete-data">
-    :) {{ $t('settings.deleteUserAccount.adminInfo') }}
   </base-card>
 </template>
 

--- a/webapp/components/DeleteData/DeleteData.vue
+++ b/webapp/components/DeleteData/DeleteData.vue
@@ -1,5 +1,5 @@
 <template>
-  <base-card class="delete-data">
+  <base-card v-if="currentUser.role !== 'admin'" class="delete-data">
     <h2 class="title">
       <base-icon name="warning" />
       {{ $t('settings.deleteUserAccount.name') }}
@@ -9,23 +9,31 @@
     </label>
     <ds-input v-model="enableDeletionValue" />
     <p class="notice">{{ $t('settings.deleteUserAccount.accountDescription') }}</p>
-    <label v-if="currentUser.contributionsCount" class="checkbox">
+    <label class="checkbox">
       <input type="checkbox" v-model="deleteContributions" />
       {{
-        $t('settings.deleteUserAccount.contributionsCount', {
-          count: currentUser.contributionsCount,
-        })
+        $t(
+          'settings.deleteUserAccount.contributionsCount',
+          {
+            count: currentUserCount.contributionsCount,
+          },
+          currentUserCount.contributionsCount,
+        )
       }}
     </label>
-    <label v-if="currentUser.commentedCount" class="checkbox">
+    <label class="checkbox">
       <input type="checkbox" v-model="deleteComments" />
       {{
-        $t('settings.deleteUserAccount.commentedCount', {
-          count: currentUser.commentedCount,
-        })
+        $t(
+          'settings.deleteUserAccount.commentedCount',
+          {
+            count: currentUserCount.commentedCount,
+          },
+          currentUserCount.commentedCount,
+        )
       }}
     </label>
-    <section v-if="deleteEnabled" class="warning">
+    <section class="warning">
       <p>{{ $t('settings.deleteUserAccount.accountWarning') }}</p>
     </section>
     <base-button
@@ -39,11 +47,15 @@
       {{ $t('settings.deleteUserAccount.name') }}
     </base-button>
   </base-card>
+  <base-card v-else class="delete-data">
+    :) {{ $t('settings.deleteUserAccount.adminInfo') }}
+  </base-card>
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex'
+import { mapActions, mapGetters } from 'vuex'
 import gql from 'graphql-tag'
+import { currentUserCountQuery } from '~/graphql/User'
 
 export default {
   name: 'DeleteData',
@@ -52,7 +64,18 @@ export default {
       deleteContributions: false,
       deleteComments: false,
       enableDeletionValue: null,
+      currentUserCount: [],
     }
+  },
+  apollo: {
+    currentUser: {
+      query() {
+        return currentUserCountQuery()
+      },
+      update(currentUser) {
+        this.currentUserCount = currentUser.currentUser
+      },
+    },
   },
   computed: {
     ...mapGetters({

--- a/webapp/components/DeleteData/DeleteData.vue
+++ b/webapp/components/DeleteData/DeleteData.vue
@@ -10,7 +10,11 @@
     <ds-input v-model="enableDeletionValue" />
     <p class="notice">{{ $t('settings.deleteUserAccount.accountDescription') }}</p>
     <label class="checkbox">
-      <input type="checkbox" v-model="deleteContributions" data-test="contributions-deletion-checkbox"/>
+      <input
+        type="checkbox"
+        v-model="deleteContributions"
+        data-test="contributions-deletion-checkbox"
+      />
       {{
         $t(
           'settings.deleteUserAccount.contributionsCount',

--- a/webapp/components/DeleteData/DeleteData.vue
+++ b/webapp/components/DeleteData/DeleteData.vue
@@ -15,9 +15,9 @@
         $t(
           'settings.deleteUserAccount.contributionsCount',
           {
-            count: currentUserCount.contributionsCount,
+            count: currentUserCounts.contributionsCount,
           },
-          currentUserCount.contributionsCount,
+          currentUserCounts.contributionsCount,
         )
       }}
     </label>
@@ -27,9 +27,9 @@
         $t(
           'settings.deleteUserAccount.commentedCount',
           {
-            count: currentUserCount.commentedCount,
+            count: currentUserCounts.commentedCount,
           },
-          currentUserCount.commentedCount,
+          currentUserCounts.commentedCount,
         )
       }}
     </label>
@@ -61,7 +61,7 @@ export default {
       deleteContributions: false,
       deleteComments: false,
       enableDeletionValue: null,
-      currentUserCount: [],
+      currentUserCounts: {},
     }
   },
   apollo: {
@@ -70,7 +70,7 @@ export default {
         return currentUserCountQuery()
       },
       update(currentUser) {
-        this.currentUserCount = currentUser.currentUser
+        this.currentUserCounts = currentUser.currentUser
       },
     },
   },

--- a/webapp/components/DeleteData/DeleteData.vue
+++ b/webapp/components/DeleteData/DeleteData.vue
@@ -10,7 +10,7 @@
     <ds-input v-model="enableDeletionValue" />
     <p class="notice">{{ $t('settings.deleteUserAccount.accountDescription') }}</p>
     <label class="checkbox">
-      <input type="checkbox" v-model="deleteContributions" />
+      <input type="checkbox" v-model="deleteContributions" data-test="contributions-deletion-checkbox"/>
       {{
         $t(
           'settings.deleteUserAccount.contributionsCount',
@@ -22,7 +22,7 @@
       }}
     </label>
     <label class="checkbox">
-      <input type="checkbox" v-model="deleteComments" />
+      <input type="checkbox" v-model="deleteComments" data-test="comments-deletion-checkbox" />
       {{
         $t(
           'settings.deleteUserAccount.commentedCount',

--- a/webapp/components/DeleteData/DeleteData.vue
+++ b/webapp/components/DeleteData/DeleteData.vue
@@ -61,8 +61,8 @@ export default {
   name: 'DeleteData',
   data() {
     return {
-      deleteContributions: true,
-      deleteComments: true,
+      deleteContributions: false,
+      deleteComments: false,
       enableDeletionValue: null,
       currentUserCount: [],
     }

--- a/webapp/graphql/User.js
+++ b/webapp/graphql/User.js
@@ -265,11 +265,9 @@ export const checkSlugAvailableQuery = gql`
 
 export const currentUserQuery = gql`
   ${userFragment}
-  ${userCountsFragment}
   query {
     currentUser {
       ...user
-      ...userCounts
       email
       role
       about

--- a/webapp/graphql/User.js
+++ b/webapp/graphql/User.js
@@ -283,3 +283,12 @@ export const currentUserQuery = gql`
     }
   }
 `
+
+export const currentUserCountQuery = () => gql`
+  ${userCountsFragment}
+  query {
+    currentUser {
+      ...userCounts
+    }
+  }
+`

--- a/webapp/locales/de.json
+++ b/webapp/locales/de.json
@@ -632,7 +632,6 @@
     "deleteUserAccount": {
       "accountDescription": "Sei dir bewusst, dass deine Beiträge und Kommentare für unsere Community wichtig sind. Wenn du sie trotzdem löschen möchtest, musst du sie unten markieren.",
       "accountWarning": "Dein Konto, deine Beiträge oder Kommentare kannst du nach dem Löschen WEDER VERWALTEN NOCH WIEDERHERSTELLEN!",
-      "adminInfo": "Der Kapitän verlässt immer als letzter das Schiff! Du bist Admin dieses Netzwerkes, du kannst dich auf diese weise nicht löschen! ;) ",
       "commentedCount": "Meinen {count} Kommentar löschen ::: Meine {count} Kommentare löschen",
       "contributionsCount": "Meinen {count} Beitrag löschen ::: Meine {count} Beiträge löschen",
       "name": "Benutzerkonto löschen",

--- a/webapp/locales/de.json
+++ b/webapp/locales/de.json
@@ -630,9 +630,9 @@
       "success": "Deine Daten wurden erfolgreich aktualisiert!"
     },
     "deleteUserAccount": {
-      "adminInfo": "Der Kapitän verlässt immer als letzter das Schiff! Du bist Admin dieses Netzwerkes, du kannst dich auf diese weise nicht löschen! ;) ",
       "accountDescription": "Sei dir bewusst, dass deine Beiträge und Kommentare für unsere Community wichtig sind. Wenn du sie trotzdem löschen möchtest, musst du sie unten markieren.",
       "accountWarning": "Dein Konto, deine Beiträge oder Kommentare kannst du nach dem Löschen WEDER VERWALTEN NOCH WIEDERHERSTELLEN!",
+      "adminInfo": "Der Kapitän verlässt immer als letzter das Schiff! Du bist Admin dieses Netzwerkes, du kannst dich auf diese weise nicht löschen! ;) ",
       "commentedCount": "Meinen {count} Kommentar löschen ::: Meine {count} Kommentare löschen",
       "contributionsCount": "Meinen {count} Beitrag löschen ::: Meine {count} Beiträge löschen",
       "name": "Benutzerkonto löschen",

--- a/webapp/locales/de.json
+++ b/webapp/locales/de.json
@@ -630,10 +630,11 @@
       "success": "Deine Daten wurden erfolgreich aktualisiert!"
     },
     "deleteUserAccount": {
+      "adminInfo": "Der Kapitän verlässt immer als letzter das Schiff! Du bist Admin dieses Netzwerkes, du kannst dich auf diese weise nicht löschen! ;) ",
       "accountDescription": "Sei dir bewusst, dass deine Beiträge und Kommentare für unsere Community wichtig sind. Wenn du sie trotzdem löschen möchtest, musst du sie unten markieren.",
       "accountWarning": "Dein Konto, deine Beiträge oder Kommentare kannst du nach dem Löschen WEDER VERWALTEN NOCH WIEDERHERSTELLEN!",
-      "commentedCount": "Meine {count} Kommentare löschen",
-      "contributionsCount": "Meine {count} Beiträge löschen",
+      "commentedCount": "Meinen {count} Kommentar löschen ::: Meine {count} Kommentare löschen",
+      "contributionsCount": "Meinen {count} Beitrag löschen ::: Meine {count} Beiträge löschen",
       "name": "Benutzerkonto löschen",
       "pleaseConfirm": "Zerstörerische Aktion! Gib „{confirm}“ ein, um zu bestätigen.",
       "success": "Konto erfolgreich gelöscht!"

--- a/webapp/locales/en.json
+++ b/webapp/locales/en.json
@@ -632,7 +632,6 @@
     "deleteUserAccount": {
       "accountDescription": "Be aware that your Posts and Comments are important to our community. If you still choose to delete them, you have to mark them below.",
       "accountWarning": "You CAN'T MANAGE and CAN'T RECOVER your Account, Posts, or Comments after deleting your account!",
-      "adminInfo": "The captain is always the last to leave the ship! You are admin of this network, you cannot delete yourself this way! ;) ",
       "commentedCount": "Delete my {count} comment ::: Delete my {count} comments",
       "contributionsCount": "Delete my {count} post ::: Delete my {count} posts",
       "name": "Delete user account",

--- a/webapp/locales/en.json
+++ b/webapp/locales/en.json
@@ -630,9 +630,9 @@
       "success": "Your data was successfully updated!"
     },
     "deleteUserAccount": {
-      "adminInfo": "The captain is always the last to leave the ship! You are admin of this network, you cannot delete yourself this way! ;) ",
       "accountDescription": "Be aware that your Posts and Comments are important to our community. If you still choose to delete them, you have to mark them below.",
       "accountWarning": "You CAN'T MANAGE and CAN'T RECOVER your Account, Posts, or Comments after deleting your account!",
+      "adminInfo": "The captain is always the last to leave the ship! You are admin of this network, you cannot delete yourself this way! ;) ",
       "commentedCount": "Delete my {count} comment ::: Delete my {count} comments",
       "contributionsCount": "Delete my {count} post ::: Delete my {count} posts",
       "name": "Delete user account",

--- a/webapp/locales/en.json
+++ b/webapp/locales/en.json
@@ -630,10 +630,11 @@
       "success": "Your data was successfully updated!"
     },
     "deleteUserAccount": {
+      "adminInfo": "The captain is always the last to leave the ship! You are admin of this network, you cannot delete yourself this way! ;) ",
       "accountDescription": "Be aware that your Posts and Comments are important to our community. If you still choose to delete them, you have to mark them below.",
       "accountWarning": "You CAN'T MANAGE and CAN'T RECOVER your Account, Posts, or Comments after deleting your account!",
-      "commentedCount": "Delete my {count} comments",
-      "contributionsCount": "Delete my {count} posts",
+      "commentedCount": "Delete my {count} comment ::: Delete my {count} comments",
+      "contributionsCount": "Delete my {count} post ::: Delete my {count} posts",
       "name": "Delete user account",
       "pleaseConfirm": "Destructive action! Type “{confirm}” to confirm.",
       "success": "Account successfully deleted!"


### PR DESCRIPTION
## 🍰 Pullrequest
the checkboxes for saved contributions and comments of a user are displayed again at userDelete

### Issues
- fixes #3498 
 