### PR TITLE
feat: [WIP] Tag cloud on 'post' and 'more-info' pages are alphabetically sorted...

### DIFF
--- a/webapp/pages/post/_id/_slug/index.spec.js
+++ b/webapp/pages/post/_id/_slug/index.spec.js
@@ -3,6 +3,7 @@ import Vuex from 'vuex'
 import Vue from 'vue'
 import PostSlug from './index.vue'
 import CommentList from '~/components/CommentList/CommentList'
+import HcHashtag from '~/components/Hashtag/Hashtag'
 
 config.stubs['client-only'] = '<span><slot /></span>'
 config.stubs['nuxt-link'] = '<span><slot /></span>'
@@ -141,6 +142,49 @@ describe('PostSlug', () => {
           id: 'commentAuthorId',
           slug: 'ogerly',
         })
+      })
+    })
+
+    describe('tags shown in tag cloud', () => {
+      beforeEach(async () => {
+        // Create backendData with tags, not alphabetically sorted.
+        backendData.post.tags = [
+          { id: 'c' },
+          { id: 'qw' },
+          { id: 'BQ' },
+          { id: '42' },
+          { id: 'Bw' },
+          { id: 'a' },
+        ]
+
+        wrapper = await Wrapper()
+      })
+
+      it('are present', async () => {
+        // Get length from backendData and compare against number of tags present in component.
+        expect(wrapper.findAll(HcHashtag).length).toBe(backendData.post.tags.length)
+      })
+
+      it('are alphabetically ordered', async () => {
+        // Get all HcHastag components
+        const wrappers = wrapper.findAll(HcHashtag).wrappers
+        // Exctract ID properties (tag names) from component.
+        const ids = []
+        wrappers.forEach((x) => {
+          ids.push({
+            id: x.props().id,
+          })
+        })
+        // Compare extracted IDs with solution.
+        const idsAlphabetically = [
+          { id: '42' },
+          { id: 'a' },
+          { id: 'BQ' },
+          { id: 'Bw' },
+          { id: 'c' },
+          { id: 'qw' },
+        ]
+        expect(ids).toStrictEqual(idsAlphabetically)
       })
     })
   })

--- a/webapp/pages/post/_id/_slug/index.vue
+++ b/webapp/pages/post/_id/_slug/index.vue
@@ -64,7 +64,7 @@
       <!-- Tags -->
       <div v-if="post.tags && post.tags.length" class="tags">
         <ds-space margin="xx-small" />
-        <hc-hashtag v-for="tag in post.tags" :key="tag.id" :id="tag.id" />
+        <hc-hashtag v-for="tag in sortedTags" :key="tag.id" :id="tag.id" />
       </div>
       <ds-space margin-top="x-large">
         <ds-flex :gutter="{ lg: 'small' }">
@@ -178,6 +178,20 @@ export default {
       const { author } = this.post
       if (!author) return false
       return this.$store.getters['auth/user'].id === author.id
+    },
+    sortedTags() {
+      // Make sure the property is valid.
+      if (!this.post.tags || !this.post.tags.length) return false
+      /*  Using .slice(0) to make a shallow copy. Otherwise a vue/no-side-effects-in-computed-properties error
+          would be thrown because sort() sorts in place. A shallow copy is fine because only first level objects are
+          affected by the sort, the original this.post.tags object remains unchanged.
+      */
+      return this.post.tags.slice(0).sort(function (a, b) {
+        // Converting to lowercase to make sort case insensitive.
+        const tagA = a.id.toLowerCase()
+        const tagB = b.id.toLowerCase()
+        return tagA < tagB ? -1 : tagA > tagB ? 1 : 0
+      })
     },
   },
   methods: {

--- a/webapp/pages/post/_id/_slug/more-info.vue
+++ b/webapp/pages/post/_id/_slug/more-info.vue
@@ -14,7 +14,7 @@
       <h3>
         {{ $t('post.moreInfo.titleOfHashtagsSection') }}
       </h3>
-      <hc-hashtag v-for="tag in post.tags" :key="tag.id" :id="tag.id" />
+      <hc-hashtag v-for="tag in sortedTags" :key="tag.id" :id="tag.id" />
     </template>
     <h3>{{ $t('post.moreInfo.titleOfRelatedContributionsSection') }}</h3>
     <ds-section>
@@ -61,6 +61,20 @@ export default {
   computed: {
     post() {
       return this.Post ? this.Post[0] || {} : {}
+    },
+    sortedTags() {
+      // Make sure the property is valid.
+      if (!this.post.tags || !this.post.tags.length) return false
+      /*  Using .slice(0) to make a shallow copy. Otherwise a vue/no-side-effects-in-computed-properties error
+          would be thrown because sort() sorts in place. A shallow copy is fine because only first level objects are
+          affected by the sort, the original this.post.tags object remains unchanged.
+      */
+      return this.post.tags.slice(0).sort(function (a, b) {
+        // Converting to lowercase to make sort case insensitive.
+        const tagA = a.id.toLowerCase()
+        const tagB = b.id.toLowerCase()
+        return tagA < tagB ? -1 : tagA > tagB ? 1 : 0
+      })
     },
   },
   methods: {


### PR DESCRIPTION
…using computed properties. An added jest test case confirms they are present and sorted on the 'post' page.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
As an alternative to using computed properties, the tags could also be sorted in `apollo`'s `update` function but I think this solution's intentions are clearer. Code is finished but still a [WIP] because some tests fail but it's weird, more details below.

**sidenote**: I took the liberty of making a pull request without being assigned, I hope this is OK. I fancied Human-Connections' stack so I'd thought I'd try out some good first issues to get to know it better.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #2244

### Test
- Front-end ✔️
- Lint ✔️
- Back-end ❔
- End-to-end ❔

Both end-to-end and back-end **tests don't even work on a clean master git clone** while the app works when developing. Since some things have to be done through WSL in order to work (like `yarn test .\pages\post\_id\_slug\index.spec.js`) I think this might have to do with me developing on a windows machine (windows 10 Pro 1909). This pull request/fix is pretty minimal so it shouldn't break anything end-to-end or back-end wise. If anyone with a working test suite can verify...

This is the error for end-to-end tests:
```
 Running:  administration\PinPost.feature                                                 (1 of 19)


  Pin a post
    √ Pinned post always appears on the top of the newsfeed (23921ms)
    √ Ordinary users cannot pin a post (15954ms)
    1) "before each" hook for "Admins are allowed to pin a post"


  2 passing (1m)
  1 failing

  1) Pin a post "before each" hook for "Admins are allowed to pin a post":
     TypeError: Cannot read property 'isAttached' of undefined

Because this error occurred during a 'before each' hook we are skipping all of the remaining tests.
      at C:\Users\dries\AppData\Local\Cypress\Cache\4.2.0\Cypress\resources\app\packages\server\lib\browsers\firefox-util.js:98:20
      at tryCatcher (C:\Users\dries\AppData\Local\Cypress\Cache\4.2.0\Cypress\resources\app\packages\server\node_modules\bluebird\js\release\util.js:16:23)
      at C:\Users\dries\AppData\Local\Cypress\Cache\4.2.0\Cypress\resources\app\packages\server\node_modules\bluebird\js\release\method.js:15:34
      at C:\Users\dries\AppData\Local\Cypress\Cache\4.2.0\Cypress\resources\app\packages\server\lib\browsers\firefox-util.js:227:40
      at tryCatcher (C:\Users\dries\AppData\Local\Cypress\Cache\4.2.0\Cypress\resources\app\packages\server\node_modules\bluebird\js\release\util.js:16:23)
      at Promise._settlePromiseFromHandler (C:\Users\dries\AppData\Local\Cypress\Cache\4.2.0\Cypress\resources\app\packages\server\node_modules\bluebird\js\release\promise.js:547:31)
      at Promise._settlePromise (C:\Users\dries\AppData\Local\Cypress\Cache\4.2.0\Cypress\resources\app\packages\server\node_modules\bluebird\js\release\promise.js:604:18)
      at Promise._settlePromise0 (C:\Users\dries\AppData\Local\Cypress\Cache\4.2.0\Cypress\resources\app\packages\server\node_modules\bluebird\js\release\promise.js:649:10)
      at Promise._settlePromises (C:\Users\dries\AppData\Local\Cypress\Cache\4.2.0\Cypress\resources\app\packages\server\node_modules\bluebird\js\release\promise.js:729:18)
      at _drainQueueStep (C:\Users\dries\AppData\Local\Cypress\Cache\4.2.0\Cypress\resources\app\packages\server\node_modules\bluebird\js\release\async.js:93:12)
      at _drainQueue (C:\Users\dries\AppData\Local\Cypress\Cache\4.2.0\Cypress\resources\app\packages\server\node_modules\bluebird\js\release\async.js:86:9)
      at Async._drainQueues (C:\Users\dries\AppData\Local\Cypress\Cache\4.2.0\Cypress\resources\app\packages\server\node_modules\bluebird\js\release\async.js:102:5)
      at Immediate.Async.drainQueues [as _onImmediate] (C:\Users\dries\AppData\Local\Cypress\Cache\4.2.0\Cypress\resources\app\packages\server\node_modules\bluebird\js\release\async.js:15:14)
      at processImmediate (internal/timers.js:439:21)
```
And these are the failed back-end tests:
```
Summary of all failing tests
 FAIL  src/schema/resolvers/reports.spec.js (126.348s)
  ● file a report on a resource › query for reported resource › unauthenticated › throws authorization error

    Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Error: Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.

      at mapper (node_modules/jest-jasmine2/build/queueRunner.js:27:45)

 FAIL  src/middleware/notifications/notificationsMiddleware.spec.js (61.567s)
  ● notifications › authenticated › given another user › mentions me in a post › updates the post and 
mentions me again › if the notification was marked as read earlier › but the next mention happens after the notification was marked as read › sets the `read` attribute to false again

    : Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Error:
      378 | 
      379 |             describe('but the next mention happens after the notification was marked as read', () => {
    > 380 |               it('sets the `read` attribute to false again', async () => {
          |               ^
      381 |                 await createPostAction()
      382 |                 await markAsReadAction()
      383 |                 const {

      at new Spec (node_modules/jest-jasmine2/build/jasmine/Spec.js:116:22)
      at Suite.<anonymous> (src/middleware/notifications/notificationsMiddleware.spec.js:380:15)
      at Suite.<anonymous> (src/middleware/notifications/notificationsMiddleware.spec.js:379:13)
      at Suite.<anonymous> (src/middleware/notifications/notificationsMiddleware.spec.js:367:11)
      at Suite.<anonymous> (src/middleware/notifications/notificationsMiddleware.spec.js:307:9)
      at Suite.<anonymous> (src/middleware/notifications/notificationsMiddleware.spec.js:253:7)
      at Suite.<anonymous> (src/middleware/notifications/notificationsMiddleware.spec.js:108:5)
      at Suite.<anonymous> (src/middleware/notifications/notificationsMiddleware.spec.js:103:3)
      at Object.<anonymous> (src/middleware/notifications/notificationsMiddleware.spec.js:81:1)

  ● notifications › authenticated › given another user › mentions me in a post › updates the post and 
mentions me again › if the notification was marked as read earlier › but the next mention happens after the notification was marked as read › does not update the `createdAt` attribute

    : Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Error:
      400 |               })
      401 | 
    > 402 |               it('does not update the `createdAt` attribute', async () => {
          |               ^
      403 |                 await createPostAction()
      404 |                 await markAsReadAction()
      405 |                 const {

      at new Spec (node_modules/jest-jasmine2/build/jasmine/Spec.js:116:22)
      at Suite.<anonymous> (src/middleware/notifications/notificationsMiddleware.spec.js:402:15)
      at Suite.<anonymous> (src/middleware/notifications/notificationsMiddleware.spec.js:379:13)
      at Suite.<anonymous> (src/middleware/notifications/notificationsMiddleware.spec.js:367:11)
      at Suite.<anonymous> (src/middleware/notifications/notificationsMiddleware.spec.js:307:9)
      at Suite.<anonymous> (src/middleware/notifications/notificationsMiddleware.spec.js:253:7)
      at Suite.<anonymous> (src/middleware/notifications/notificationsMiddleware.spec.js:108:5)
      at Suite.<anonymous> (src/middleware/notifications/notificationsMiddleware.spec.js:103:3)
      at Object.<anonymous> (src/middleware/notifications/notificationsMiddleware.spec.js:81:1)


Test Suites: 2 failed, 38 passed, 40 total
Tests:       3 failed, 1 skipped, 1 todo, 455 passed, 460 total
Snapshots:   0 total
Time:        1342.549s, estimated 1356s
```