### PR TITLE
feat: 🍰 display, select and upload UserProfile header image

### DIFF
--- a/backend/src/db/factories.js
+++ b/backend/src/db/factories.js
@@ -91,14 +91,22 @@ Factory.define('user')
       url: faker.internet.avatar(),
     }),
   )
+  /*  Defaults to false since a lot of existing tests are based on finding a certain
+      amount of images without further checks causing them to fail when finding these
+      extra profile header images. A couple of users are given profile headers
+      explicitly in seed.js.
+  */
+  .option('profileHeader', () => false)
   .after(async (buildObject, options) => {
-    const [user, email, avatar] = await Promise.all([
+    const [user, email, avatar, profileHeader] = await Promise.all([
       neode.create('User', buildObject),
       neode.create('EmailAddress', { email: options.email }),
       options.avatar,
+      options.profileHeader,
     ])
     await Promise.all([user.relateTo(email, 'primaryEmail'), email.relateTo(user, 'belongsTo')])
     if (avatar) await user.relateTo(avatar, 'avatar')
+    if (profileHeader) await user.relateTo(profileHeader, 'profileHeader')
     return user
   })
 

--- a/backend/src/db/seed.js
+++ b/backend/src/db/seed.js
@@ -168,6 +168,7 @@ const languages = ['de', 'en', 'es', 'fr', 'it', 'pt', 'pl']
         },
         {
           email: 'moderator@example.org',
+          profileHeader: Factory.build('image'),
         },
       ),
       Factory.build(
@@ -180,6 +181,7 @@ const languages = ['de', 'en', 'es', 'fr', 'it', 'pt', 'pl']
         },
         {
           email: 'user@example.org',
+          profileHeader: Factory.build('image'),
         },
       ),
       Factory.build(
@@ -192,6 +194,7 @@ const languages = ['de', 'en', 'es', 'fr', 'it', 'pt', 'pl']
         },
         {
           email: 'huey@example.org',
+          profileHeader: Factory.build('image'),
         },
       ),
       Factory.build(

--- a/backend/src/db/seed.js
+++ b/backend/src/db/seed.js
@@ -181,7 +181,6 @@ const languages = ['de', 'en', 'es', 'fr', 'it', 'pt', 'pl']
         },
         {
           email: 'user@example.org',
-          profileHeader: Factory.build('image'),
         },
       ),
       Factory.build(

--- a/backend/src/middleware/softDelete/softDeleteMiddleware.js
+++ b/backend/src/middleware/softDelete/softDeleteMiddleware.js
@@ -18,6 +18,7 @@ const obfuscate = async (resolve, root, args, context, info) => {
     root.title = 'UNAVAILABLE'
     root.slug = 'UNAVAILABLE'
     root.avatar = null
+    root.profileHeader = null
     root.about = 'UNAVAILABLE'
     root.name = 'UNAVAILABLE'
     root.image = null

--- a/backend/src/middleware/softDelete/softDeleteMiddleware.spec.js
+++ b/backend/src/middleware/softDelete/softDeleteMiddleware.spec.js
@@ -41,6 +41,9 @@ beforeAll(async () => {
         avatar: Factory.build('image', {
           url: '/some/offensive/avatar.jpg',
         }),
+        profileHeader: Factory.build('image', {
+          url: '/some/offensive/profileHeader.jpg',
+        }),
       },
     ),
     neode.create('Category', {
@@ -225,6 +228,9 @@ describe('softDeleteMiddleware', () => {
               avatar {
                 url
               }
+              profileHeader {
+                url
+              }
             }
           }
         }
@@ -270,6 +276,10 @@ describe('softDeleteMiddleware', () => {
           expect(subject.avatar).toEqual({
             url: expect.stringContaining('/some/offensive/avatar.jpg'),
           }))
+        it('display profile header', () =>
+          expect(subject.profileHeader).toEqual({
+            url: expect.stringContaining('/some/offensive/profileHeader.jpg'),
+          }))
       })
 
       describe('Post', () => {
@@ -308,6 +318,7 @@ describe('softDeleteMiddleware', () => {
         it('obfuscates slug', () => expect(subject.slug).toEqual('UNAVAILABLE'))
         it('obfuscates about', () => expect(subject.about).toEqual('UNAVAILABLE'))
         it('obfuscates avatar', () => expect(subject.avatar).toEqual(null))
+        it('obfuscates profile header', () => expect(subject.profileHeader).toEqual(null))
       })
 
       describe('Post', () => {

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -12,6 +12,12 @@ export default {
     target: 'Image',
     direction: 'out',
   },
+  profileHeader: {
+    type: 'relationship',
+    relationship: 'PROFILE_HEADER_IMAGE',
+    target: 'Image',
+    direction: 'out',
+  },
   deleted: { type: 'boolean', default: false },
   disabled: { type: 'boolean', default: false },
   role: { type: 'string', default: 'user' },

--- a/backend/src/schema/resolvers/images/images.js
+++ b/backend/src/schema/resolvers/images/images.js
@@ -105,7 +105,7 @@ const uploadImageFile = async (upload, uploadCallback) => {
 const sanitizeRelationshipType = (relationshipType) => {
   // Cypher query language does not allow to parameterize relationship types
   // See: https://github.com/neo4j/neo4j/issues/340
-  if (!['HERO_IMAGE', 'AVATAR_IMAGE'].includes(relationshipType)) {
+  if (!['HERO_IMAGE', 'AVATAR_IMAGE', 'PROFILE_HEADER_IMAGE'].includes(relationshipType)) {
     throw new Error(`Unknown relationship type ${relationshipType}`)
   }
 }

--- a/backend/src/schema/resolvers/passwordReset.spec.js
+++ b/backend/src/schema/resolvers/passwordReset.spec.js
@@ -25,6 +25,7 @@ beforeEach(() => {
 })
 
 beforeAll(() => {
+  cleanDatabase()
   const { server } = createServer({
     context: () => {
       return {

--- a/backend/src/schema/resolvers/statistics.spec.js
+++ b/backend/src/schema/resolvers/statistics.spec.js
@@ -21,7 +21,9 @@ const statisticsQuery = gql`
     }
   }
 `
-beforeAll(() => {
+beforeAll(async () => {
+  // Clean the database so no artifacts from other test files are interfering.
+  await cleanDatabase()
   authenticatedUser = undefined
   const { server } = createServer({
     context: () => {

--- a/backend/src/schema/resolvers/user_management.spec.js
+++ b/backend/src/schema/resolvers/user_management.spec.js
@@ -109,6 +109,9 @@ describe('currentUser', () => {
         avatar {
           url
         }
+        profileHeader {
+          url
+        }
         email
         role
       }
@@ -142,6 +145,9 @@ describe('currentUser', () => {
             avatar: Factory.build('image', {
               url: 'https://s3.amazonaws.com/uifaces/faces/twitter/jimmuirhead/128.jpg',
             }),
+            profileHeader: Factory.build('image', {
+              url: 'https://s3.amazonaws.com/uifaces/faces/twitter/hellofeverrrr/128.jpg',
+            }),
           },
         )
         const userBearerToken = encode({ id: 'u3' })
@@ -155,6 +161,9 @@ describe('currentUser', () => {
               id: 'u3',
               avatar: Factory.build('image', {
                 url: 'https://s3.amazonaws.com/uifaces/faces/twitter/jimmuirhead/128.jpg',
+              }),
+              profileHeader: Factory.build('image', {
+                url: 'https://s3.amazonaws.com/uifaces/faces/twitter/hellofeverrrr/128.jpg',
               }),
               email: 'test@example.org',
               name: 'Matilde Hermiston',

--- a/backend/src/schema/resolvers/users.js
+++ b/backend/src/schema/resolvers/users.js
@@ -140,8 +140,9 @@ export default {
     },
     UpdateUser: async (_parent, params, context, _resolveInfo) => {
       const { termsAndConditionsAgreedVersion } = params
-      const { avatar: avatarInput } = params
+      const { avatar: avatarInput, profileHeader: profileHeaderInput } = params
       delete params.avatar
+      delete params.profileHeader
       if (termsAndConditionsAgreedVersion) {
         const regEx = new RegExp(/^[0-9]+\.[0-9]+\.[0-9]+$/g)
         if (!regEx.test(termsAndConditionsAgreedVersion)) {
@@ -164,6 +165,9 @@ export default {
         const [user] = updateUserTransactionResponse.records.map((record) => record.get('user'))
         if (avatarInput) {
           await mergeImage(user, 'AVATAR_IMAGE', avatarInput, { transaction })
+        }
+        if (profileHeaderInput) {
+          await mergeImage(user, 'PROFILE_HEADER_IMAGE', profileHeaderInput, { transaction })
         }
         return user
       })
@@ -235,6 +239,7 @@ export default {
         log(deleteUserTransactionResponse)
         const [user] = deleteUserTransactionResponse.records.map((record) => record.get('user'))
         await deleteImage(user, 'AVATAR_IMAGE', { transaction })
+        await deleteImage(user, 'PROFILE_HEADER_IMAGE', { transaction })
         return user
       })
       try {
@@ -291,6 +296,7 @@ export default {
       },
       hasOne: {
         avatar: '-[:AVATAR_IMAGE]->(related:Image)',
+        profileHeader: '-[:PROFILE_HEADER_IMAGE]->(related:Image)',
         invitedBy: '<-[:INVITED]-(related:User)',
         location: '-[:IS_IN]->(related:Location)',
       },

--- a/backend/src/schema/resolvers/users.spec.js
+++ b/backend/src/schema/resolvers/users.spec.js
@@ -341,11 +341,17 @@ describe('DeleteUser', () => {
     beforeEach(async () => {
       variables = { id: ' u343', resource: [] }
 
-      user = await Factory.build('user', {
-        name: 'My name should be deleted',
-        about: 'along with my about',
-        id: 'u343',
-      })
+      user = await Factory.build(
+        'user',
+        {
+          name: 'My name should be deleted',
+          about: 'along with my about',
+          id: 'u343',
+        },
+        {
+          profileHeader: Factory.build('image'),
+        },
+      )
     })
 
     describe('authenticated as Admin', () => {
@@ -496,8 +502,8 @@ describe('DeleteUser', () => {
                 ).resolves.toMatchObject(expectedResponse)
               })
 
-              it('deletes user avatar and post hero images', async () => {
-                await expect(neode.all('Image')).resolves.toHaveLength(22)
+              it('deletes user avatar, profile header and post hero images', async () => {
+                await expect(neode.all('Image')).resolves.toHaveLength(23)
                 await mutate({ mutation: deleteUserMutation, variables })
                 await expect(neode.all('Image')).resolves.toHaveLength(20)
               })
@@ -627,11 +633,17 @@ describe('DeleteUser', () => {
     beforeEach(async () => {
       variables = { id: 'u343', resource: [] }
 
-      user = await Factory.build('user', {
-        name: 'My name should be deleted',
-        about: 'along with my about',
-        id: 'u343',
-      })
+      user = await Factory.build(
+        'user',
+        {
+          name: 'My name should be deleted',
+          about: 'along with my about',
+          id: 'u343',
+        },
+        {
+          profileHeader: Factory.build('image'),
+        },
+      )
       await Factory.build(
         'user',
         {
@@ -792,8 +804,8 @@ describe('DeleteUser', () => {
                 ).resolves.toMatchObject(expectedResponse)
               })
 
-              it('deletes user avatar and post hero images', async () => {
-                await expect(neode.all('Image')).resolves.toHaveLength(22)
+              it('deletes user avatar, profile header and post hero images', async () => {
+                await expect(neode.all('Image')).resolves.toHaveLength(23)
                 await mutate({ mutation: deleteUserMutation, variables })
                 await expect(neode.all('Image')).resolves.toHaveLength(20)
               })

--- a/backend/src/schema/types/type/User.gql
+++ b/backend/src/schema/types/type/User.gql
@@ -26,6 +26,7 @@ type User {
   email: String! @cypher(statement: "MATCH (this)-[:PRIMARY_EMAIL]->(e:EmailAddress) RETURN e.email")
   slug: String!
   avatar: Image @relation(name: "AVATAR_IMAGE", direction: "OUT")
+  profileHeader: Image @relation(name: "PROFILE_HEADER_IMAGE", direction: "OUT")
   deleted: Boolean
   disabled: Boolean
   role: UserGroup!
@@ -192,6 +193,7 @@ type Mutation {
   email: String
   slug: String
   avatar: ImageInput
+  profileHeader: ImageInput
   locationName: String
   about: String
   termsAndConditionsAgreedVersion: String

--- a/cypress/features.md
+++ b/cypress/features.md
@@ -38,6 +38,7 @@ The following features will be implemented. This gets done in three steps:
 
 * Upload and Change Avatar
 * Upload and Change Profile Picture
+* Upload and Change Profile Header Image
 * Edit Social Media Accounts
 * Edit Locale information
 * Show and delete Bookmarks \(later\)

--- a/cypress/integration/common/profile.js
+++ b/cypress/integration/common/profile.js
@@ -24,13 +24,39 @@ Then("I should be able to change my profile picture", () => {
   );
 });
 
+Then("I should be able to change my profile header picture", () => {
+  const headerUpload = "onourjourney.png";
+
+  cy.fixture(headerUpload, "base64").then(fileContent => {
+    cy.get("#profileHeaderDropzone").upload(
+      { fileContent, fileName: headerUpload, mimeType: "image/png" },
+      { subjectType: "drag-n-drop", force: true }
+    );
+  });
+  cy.get(".profile-header-image")
+    .should("have.attr", "src")
+    .and("contains", "onourjourney");
+  cy.contains(".iziToast-message", "Upload successful").should(
+    "have.length",
+    1
+  );
+});
+
 When("I visit another user's profile page", () => {
   cy.openPage("profile/peter-pan");
 });
 
-Then("I cannot upload a picture", () => {
+Then("I cannot upload a profile picture", () => {
   cy.get(".base-card")
     .children()
     .should("not.have.id", "customdropzone")
     .should("have.class", "user-avatar");
+});
+
+
+Then("I cannot upload a profile header image", () => {
+  cy.get(".base-card")
+    .children()
+    .should("not.have.id", "profileHeaderDropzone")
+    .should("have.class", "profile-header");
 });

--- a/cypress/integration/user_profile/UploadUserProfileHeader.feature
+++ b/cypress/integration/user_profile/UploadUserProfileHeader.feature
@@ -1,0 +1,18 @@
+Feature: Upload UserProfile Header
+  As a user
+  I would like to be able to add a profile header pic to my profile
+  So that I can personalize my profile
+
+
+  Background:
+    Given I have a user account
+
+  Scenario: Change my UserProfile Header
+    Given I am logged in
+    And I visit my profile page
+    Then I should be able to change my profile header picture
+
+  Scenario: Unable to change another user's header images
+    Given I am logged in with a "user" role
+    And I visit another user's profile page
+    Then I cannot upload a profile header image

--- a/cypress/integration/user_profile/UploadUserProfileImage.feature
+++ b/cypress/integration/user_profile/UploadUserProfileImage.feature
@@ -15,4 +15,4 @@ Feature: Upload UserProfile Image
   Scenario: Unable to change another user's avatar
     Given I am logged in with a "user" role
     And I visit another user's profile page
-    Then I cannot upload a picture
+    Then I cannot upload a profile picture

--- a/webapp/components/_new/generic/UserProfileHeader/UserProfileHeader.vue
+++ b/webapp/components/_new/generic/UserProfileHeader/UserProfileHeader.vue
@@ -1,0 +1,224 @@
+<template>
+  <div class="profile-header">
+    <vue-dropzone
+      v-if="user && this.editable"
+      id="profileHeaderDropzone"
+      :key="profileHeaderUrl"
+      ref="el"
+      :use-custom-slot="true"
+      :options="dropzoneOptions"
+      @vdropzone-error="verror"
+    >
+      <div class="dz-message" @mouseover="hover = true" @mouseleave="hover = false">
+        <img
+          v-if="user && user.profileHeader"
+          :src="user.profileHeader | proxyApiUrl"
+          @error="$event.target.style.display = 'none'"
+          class="profile-header-image"
+          :alt="imageAlt"
+        />
+        <div class="profileHeader-attachments-upload-area">
+          <div class="profileHeader-drag-marker">
+            <base-icon v-if="hover" name="image" />
+          </div>
+        </div>
+      </div>
+    </vue-dropzone>
+    <div v-else>
+      <img
+        v-if="user && user.profileHeader"
+        :src="user.profileHeader | proxyApiUrl"
+        @error="$event.target.style.display = 'none'"
+        class="profile-header-image"
+        :alt="imageAlt"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import vueDropzone from 'nuxt-dropzone'
+import { updateUserMutation } from '~/graphql/User.js'
+
+export default {
+  name: 'UserProfileHeader',
+  components: {
+    vueDropzone,
+  },
+  props: {
+    user: {
+      type: Object,
+      default: null,
+    },
+    editable: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      dropzoneOptions: {
+        url: this.vddrop,
+        maxFilesize: 5.0,
+        previewTemplate: this.template(),
+      },
+      error: false,
+      hover: false,
+    }
+  },
+  computed: {
+    imageAlt() {
+      if (!this.user && !this.user.name) return 'Profile header image'
+      return 'Profile header image of ' + this.user.name
+    },
+    profileHeaderUrl() {
+      const { profileHeader } = this.user
+      return profileHeader && profileHeader.url
+    },
+  },
+  watch: {
+    error() {
+      const that = this
+      setTimeout(function () {
+        that.error = false
+      }, 2000)
+    },
+  },
+  methods: {
+    template() {
+      return `<div class="dz-preview dz-file-preview">
+                <div class="dz-image">
+                  <div data-dz-thumbnail-bg></div>
+                </div>
+              </div>
+      `
+    },
+    vddrop(file) {
+      const profileHeaderUpload = file[0]
+      this.$apollo
+        .mutate({
+          mutation: updateUserMutation(),
+          variables: {
+            profileHeader: {
+              upload: profileHeaderUpload,
+            },
+            id: this.user.id,
+          },
+        })
+        .then(() => {
+          this.$toast.success(this.$t('user.profileHeader.submitted'))
+        })
+        .catch((error) => this.$toast.error(error.message))
+    },
+    verror(file, message) {
+      if (file.status === 'error') {
+        this.error = true
+        this.$toast.error(file.status, message)
+      }
+    },
+  },
+}
+</script>
+
+<style lang="scss">
+.profile-header {
+  height: 100%;
+  position: relative;
+  background-color: DarkGrey; /* Fallback color */
+}
+
+.profile-header-image {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+}
+
+#profileHeaderDropzone {
+  height: 100%;
+}
+
+.dz-message {
+  height: 100%;
+}
+
+#profileHeaderDropzone .dz-preview {
+  transition: all 0.2s ease-out;
+  width: 160px;
+  display: flex;
+}
+
+#profileHeaderDropzone .dz-preview .dz-image {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  overflow: hidden;
+}
+
+#profileHeaderDropzone .dz-preview .dz-image > div {
+  width: inherit;
+  height: inherit;
+  border-radius: 50%;
+  background-size: cover;
+}
+
+#profileHeaderDropzone .dz-preview .dz-image > img {
+  width: 100%;
+}
+
+.profileHeader-attachments-upload-area {
+  height: 100%;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.profileHeader-attachments-upload-button {
+  pointer-events: none;
+}
+
+.profileHeader-drag-marker {
+  position: relative;
+  width: 122px;
+  height: 122px;
+  border-radius: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: hsl(0, 0%, 25%);
+  transition: all 0.2s ease-out;
+  font-size: 60px;
+
+  background-color: rgba(255, 255, 255, 0.7);
+  opacity: 0.1;
+
+  &:before {
+    position: absolute;
+    content: '';
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    border-radius: 100%;
+    border: 20px solid rgba(255, 255, 255, 0.4);
+    visibility: hidden;
+  }
+
+  &:after {
+    position: absolute;
+    content: '';
+    top: 10px;
+    left: 10px;
+    bottom: 10px;
+    right: 10px;
+    border-radius: 100%;
+    border: 1px dashed hsl(0, 0%, 25%);
+  }
+  .profileHeader-attachments-upload-area:hover & {
+    opacity: 1;
+  }
+}
+</style>

--- a/webapp/components/_new/generic/UserProfileHeader/userProfileHeader.spec.js
+++ b/webapp/components/_new/generic/UserProfileHeader/userProfileHeader.spec.js
@@ -1,0 +1,217 @@
+import { mount, shallowMount } from '@vue/test-utils'
+import UserProfileHeader from './UserProfileHeader.vue'
+import vueDropzone from 'nuxt-dropzone'
+import Vue from 'vue'
+
+const localVue = global.localVue
+
+describe('UserProfileHeader.vue', () => {
+  let propsData, wrapper, mocks
+
+  beforeEach(() => {
+    propsData = {}
+    wrapper = Wrapper()
+  })
+
+  const Wrapper = () => {
+    return mount(UserProfileHeader, { propsData, localVue })
+  }
+
+  it('renders no image', () => {
+    expect(wrapper.contains('img')).toBe(false)
+  })
+
+  it('renders no dropzone', () => {
+    expect(wrapper.contains(vueDropzone)).toBe(false)
+  })
+
+  describe('given a user', () => {
+    describe('with no header image', () => {
+      beforeEach(() => {
+        propsData = {
+          user: {
+            name: 'Matt Rider',
+          },
+        }
+        wrapper = Wrapper()
+      })
+
+      it('renders no img tag', () => {
+        expect(wrapper.contains('img')).toBe(false)
+      })
+    })
+
+    describe('with a header image', () => {
+      beforeEach(() => {
+        propsData = {
+          user: {
+            name: 'Matt Rider',
+            profileHeader: {
+              url: 'https://source.unsplash.com/640x480',
+            },
+          },
+        }
+        wrapper = Wrapper()
+      })
+
+      it('renders an image', () => {
+        expect(wrapper.contains('img')).toBe(true)
+      })
+    })
+
+    describe('with a relative avatar url', () => {
+      beforeEach(() => {
+        propsData = {
+          user: {
+            name: 'Not Anonymous',
+            profileHeader: {
+              url: '/profileHeader.jpg',
+            },
+          },
+        }
+        wrapper = Wrapper()
+      })
+
+      it('adds a prefix to load the image from the uploads service', () => {
+        expect(wrapper.find('img').attributes('src')).toBe('/api/profileHeader.jpg')
+      })
+    })
+
+    describe('with an absolute avatar url', () => {
+      beforeEach(() => {
+        propsData = {
+          user: {
+            name: 'Not Anonymous',
+            profileHeader: {
+              url: 'https://s3.amazonaws.com/uifaces/faces/twitter/sawalazar/128.jpg',
+            },
+          },
+        }
+        wrapper = Wrapper()
+      })
+
+      it('keeps the avatar URL as is', () => {
+        // e.g. our seeds have absolute image URLs
+        expect(wrapper.find('img').attributes('src')).toBe(
+          'https://s3.amazonaws.com/uifaces/faces/twitter/sawalazar/128.jpg',
+        )
+      })
+    })
+
+    describe('on his own userpage', () => {
+      beforeEach(() => {
+        propsData = {
+          editable: true,
+          user: {
+            name: 'Not Anonymous',
+            profileHeader: {
+              url: 'https://s3.amazonaws.com/uifaces/faces/twitter/sawalazar/128.jpg',
+            },
+          },
+        }
+        wrapper = Wrapper()
+      })
+
+      it('a dropzone is present', () => {
+        expect(wrapper.contains(vueDropzone)).toBe(true)
+      })
+
+      describe('uploading and image', () => {
+        beforeAll(() => {
+          propsData = {
+            user: {
+              profileHeader: { url: '/api/profileHeader.jpg' },
+            },
+          }
+          mocks = {
+            $apollo: {
+              mutate: jest
+                .fn()
+                .mockResolvedValueOnce({
+                  data: {
+                    UpdateUser: {
+                      id: 'upload1',
+                      profileHeader: { url: '/upload/profileHeader.jpg' },
+                    },
+                  },
+                })
+                .mockRejectedValue({
+                  message: 'File upload unsuccessful!',
+                }),
+            },
+            $toast: {
+              success: jest.fn(),
+              error: jest.fn(),
+            },
+            $t: jest.fn(),
+          }
+        })
+
+        beforeEach(() => {
+          jest.useFakeTimers()
+          wrapper = shallowMount(UserProfileHeader, { localVue, propsData, mocks })
+        })
+
+        afterEach(() => {
+          jest.clearAllMocks()
+        })
+
+        it('sends a UpdateUser mutation when vddrop is called', () => {
+          wrapper.vm.vddrop([{ filename: 'profileHeader.jpg' }])
+          expect(mocks.$apollo.mutate).toHaveBeenCalledTimes(1)
+        })
+
+        describe('error handling', () => {
+          const message = 'File upload failed'
+          const fileError = { status: 'error' }
+
+          it('defaults to error false', () => {
+            expect(wrapper.vm.error).toEqual(false)
+          })
+
+          it('shows an error toaster when verror is called', () => {
+            wrapper.vm.verror(fileError, message)
+            expect(mocks.$toast.error).toHaveBeenCalledWith(fileError.status, message)
+          })
+
+          it('changes error status from false to true to false', async () => {
+            wrapper.vm.verror(fileError, message)
+            await Vue.nextTick()
+            expect(wrapper.vm.error).toEqual(true)
+            jest.runAllTimers()
+            expect(wrapper.vm.error).toEqual(false)
+          })
+
+          it('shows an error toaster when the apollo mutation rejects', async () => {
+            // calls vddrop twice because of how mockResolvedValueOnce works in jest
+            // the first time the mock function is called it will resolve, calling it a
+            // second time will cause it to fail(with this implementation)
+            // https://jestjs.io/docs/en/mock-function-api.html#mockfnmockresolvedvalueoncevalue
+            await wrapper.vm.vddrop([{ filename: 'profileHeader.jpg' }])
+            await wrapper.vm.vddrop([{ filename: 'profileHeader.jpg' }])
+            expect(mocks.$toast.error).toHaveBeenCalledTimes(1)
+          })
+        })
+      })
+    })
+
+    describe("on a different user's userpage", () => {
+      beforeEach(() => {
+        propsData = {
+          editable: false,
+          user: {
+            name: 'Not Anonymous',
+            profileHeader: {
+              url: 'https://s3.amazonaws.com/uifaces/faces/twitter/sawalazar/128.jpg',
+            },
+          },
+        }
+        wrapper = Wrapper()
+      })
+
+      it('no dropzone is present', () => {
+        expect(wrapper.contains(vueDropzone)).toBe(false)
+      })
+    })
+  })
+})

--- a/webapp/graphql/User.js
+++ b/webapp/graphql/User.js
@@ -20,6 +20,9 @@ export default (i18n) => {
         ...userCounts
         ...locationAndBadges
         about
+        profileHeader {
+          url
+        }
         locationName
         createdAt
         followedByCurrentUser
@@ -226,6 +229,7 @@ export const updateUserMutation = () => {
       $showShoutsPublicly: Boolean
       $termsAndConditionsAgreedVersion: String
       $avatar: ImageInput
+      $profileHeader: ImageInput
     ) {
       UpdateUser(
         id: $id
@@ -237,6 +241,7 @@ export const updateUserMutation = () => {
         showShoutsPublicly: $showShoutsPublicly
         termsAndConditionsAgreedVersion: $termsAndConditionsAgreedVersion
         avatar: $avatar
+        profileHeader: $profileHeader
       ) {
         id
         slug
@@ -248,6 +253,9 @@ export const updateUserMutation = () => {
         locale
         termsAndConditionsAgreedVersion
         avatar {
+          url
+        }
+        profileHeader {
           url
         }
       }

--- a/webapp/locales/de.json
+++ b/webapp/locales/de.json
@@ -830,6 +830,9 @@
   "user": {
     "avatar": {
       "submitted": "Erfolgreich hochgeladen!"
+    },
+    "profileHeader": {
+      "submitted": "Erfolgreich hochgeladen!"
     }
   }
 }

--- a/webapp/locales/en.json
+++ b/webapp/locales/en.json
@@ -830,6 +830,9 @@
   "user": {
     "avatar": {
       "submitted": "Upload successful!"
+    },
+    "profileHeader": {
+      "submitted": "Upload successful!"
     }
   }
 }

--- a/webapp/locales/es.json
+++ b/webapp/locales/es.json
@@ -827,6 +827,9 @@
   "user": {
     "avatar": {
       "submitted": "Carga con éxito"
+    },
+    "profileHeader": {
+      "submitted": "Carga con éxito!"
     }
   }
 }

--- a/webapp/locales/fr.json
+++ b/webapp/locales/fr.json
@@ -791,6 +791,9 @@
   "user": {
     "avatar": {
       "submitted": "Téléchargement réussi"
+    },
+    "profileHeader": {
+      "submitted": "Téléchargement réussi"
     }
   }
 }

--- a/webapp/locales/it.json
+++ b/webapp/locales/it.json
@@ -734,6 +734,9 @@
   "user": {
     "avatar": {
       "submitted": ""
+    },
+    "profileHeader": {
+      "submitted": "Caricamento eseguito correttamente!"
     }
   }
 }

--- a/webapp/locales/nl.json
+++ b/webapp/locales/nl.json
@@ -172,5 +172,10 @@
     "taxident": "Identificatienummer voor de belasting over de toegevoegde waarde overeenkomstig § 27 a Wet op de belasting over de toegevoegde waarde (Duitsland).",
     "termsAc": "Gebruiksvoorwaarden",
     "tribunal": "registerrechtbank"
+  },
+  "user": {
+    "profileHeader": {
+      "submitted": "Uploaden geslaagd!"
+    }
   }
 }

--- a/webapp/locales/pl.json
+++ b/webapp/locales/pl.json
@@ -363,6 +363,9 @@
   "user": {
     "avatar": {
       "submitted": "Przesłano pomyślnie"
+    },
+    "profileHeader": {
+      "submitted": "Przesłano pomyślnie"
     }
   }
 }

--- a/webapp/locales/pt.json
+++ b/webapp/locales/pt.json
@@ -722,6 +722,9 @@
   "user": {
     "avatar": {
       "submitted": "Carregado com sucesso!"
+    },
+    "profileHeader": {
+      "submitted": "Carregado com sucesso!"
     }
   }
 }

--- a/webapp/locales/ru.json
+++ b/webapp/locales/ru.json
@@ -823,6 +823,9 @@
   "user": {
     "avatar": {
       "submitted": "Успешная загрузка!"
+    },
+    "profileHeader": {
+      "submitted": "Успешная загрузка!"
     }
   }
 }

--- a/webapp/pages/profile/_id/_slug.vue
+++ b/webapp/pages/profile/_id/_slug.vue
@@ -1,7 +1,11 @@
 <template>
   <div>
-    <ds-space />
     <ds-flex v-if="user" :width="{ base: '100%' }" gutter="base">
+      <ds-flex-item width="100%">
+        <base-card class="profile-header">
+          <user-profile-header :user="user" :editable="myProfile"></user-profile-header>
+        </base-card>
+      </ds-flex-item>
       <ds-flex-item :width="{ base: '100%', sm: 2, md: 2, lg: 1 }">
         <base-card
           :class="{ 'disabled-content': user.disabled }"
@@ -242,6 +246,7 @@ import { muteUser, unmuteUser } from '~/graphql/settings/MutedUsers'
 import { blockUser, unblockUser } from '~/graphql/settings/BlockedUsers'
 import PostMutations from '~/graphql/PostMutations'
 import UpdateQuery from '~/components/utils/UpdateQuery'
+import UserProfileHeader from '~/components/_new/generic/UserProfileHeader/UserProfileHeader'
 
 const tabToFilterMapping = ({ tab, id }) => {
   return {
@@ -264,6 +269,7 @@ export default {
     MasonryGrid,
     MasonryGridItem,
     FollowList,
+    UserProfileHeader,
   },
   transition: {
     name: 'slide-up',
@@ -542,5 +548,10 @@ export default {
     width: 100%;
     margin-bottom: $space-x-small;
   }
+}
+
+.profile-header {
+  padding: 0px; /* Overwrite default card padding to 0. */
+  height: 250px;
 }
 </style>


### PR DESCRIPTION
## 🍰 Pullrequest

Since this feature is pretty similar to uploading and displaying a user's profile avatar I was able to mostly mirror the already existing implementation. Here you can see the drag and drop in action as well as the standard grey header for when no previous image is available:

![dragndrop](https://user-images.githubusercontent.com/26900172/84529426-bacf7a80-ace1-11ea-827a-3e3a6c0be0cb.gif)

Clicking opens up a file browser to select a file to upload just as with a profile avatar.

The issue also mentions cropping the image (to not use unnecessary bandwidth I assume) although I am not sure what to expected behavior is when using the app on mobile. As u can see in the next GIF, the image is mostly visible on mobile screens and even exposes the grey background if the image is not tall enough. Should the container have a max-height depending on the height of the image so no grey background is visible on wide images? Or use a CSS background image with repeat instead of an `<img>` tag?

![mobile resize](https://user-images.githubusercontent.com/26900172/84530717-aee4b800-ace3-11ea-8666-7166e686df39.gif)

<details>
<summary>Extra notes</summary>

####  `UserProfileHeader` component
I did not not reuse the `hc-upload` component since that one already has avatar specific code and the styling needs to be different. I instead (sort off) merged the `hc-upload` and `UserAvatar` component into a new `UserProfileHeader` component.

#### back-end
I did not add new tests to `image.spec.js` since already contains test functions for a profile avatar and all functionality is shared. The only thing that had to be done is add the relationship type to the array of relationship types.

I also added a `cleanDatabase()` in `passwordReset.spec.js` and `statistics.spec.js` before all tests because they would fail. Presumably because of artifacts from previous tests?

#### Db seed
Unlike avatars, profile headers are not added to user accounts by default when seeding the database. I lot of tests failed because they do a hard-coded check of the total amount of images in the database. I tried changing the amounts but I can't quite figure out why the amounts are what they are as they seem very arbitrary so I thought it best to leave them as is. This way I can just mock profile headers when needed and not break any previous tests.

#### Locales
Purposefully didn't reuse the `user.avatar.submitted` but made a  new `user.profileHeader.submitted` although the text is the same. There is no text for failed toasts because that just prints the error message.

#### Storybook
I did not add a storybook entry since the component is very basic and does not have different states. Let me know if you still think this is necessary.
</details>

### Issues
- fixes #397

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] Made header component and added it to the profile page + Graphql functionality.
- [X] Back-end functionality for the header image similar to avatar image.
- [X] Database seeds.
- [X] Unit tests web-app and back-end.
- [X] Integration tests.
- [X] Locales for the successful upload toast.
- [ ] Cropping image?