### PR TITLE
fix: issue #3504 umlaut encoding

### DIFF
--- a/backend/src/middleware/slugify/uniqueSlug.js
+++ b/backend/src/middleware/slugify/uniqueSlug.js
@@ -2,6 +2,14 @@ import slugify from 'slug'
 export default async function uniqueSlug(string, isUnique) {
   const slug = slugify(string || 'anonymous', {
     lower: true,
+    charmap: {
+        'Ä' : 'ae',
+        'ä' : 'ae',
+        'Ö' : 'oe',
+        'ö' : 'oe',
+        'Ü' : 'ue',
+        'ü' : 'ue',
+    }
   })
   if (await isUnique(slug)) return slug
 


### PR DESCRIPTION
Updated slugify middleware to handle umlauts to specification

## 🍰 Pullrequest
Bug caused by unexpected behavior of [Trott/slug](https://github.com/Trott/slug) middleware. Function only encodes to single English characters by default. According to the [documentation](https://github.com/Trott/slug/blob/master/README.md), a character map should be specified for specifically defined cases.

### Issues
- fixes #3504 


