### PR TITLE
[WIP] for archiv status: backend funktion turn of

### DIFF
--- a/backend/src/middleware/permissionsMiddleware.js
+++ b/backend/src/middleware/permissionsMiddleware.js
@@ -1,8 +1,13 @@
-import { rule, shield, deny, allow, or } from 'graphql-shield'
+import { rule, shield, deny, allow, or, and } from 'graphql-shield'
 import { getNeode } from '../db/neo4j'
 import CONFIG from '../config'
 
 const debug = !!CONFIG.DEBUG
+
+// pleace change "ARCHIV" in file cypress/constants/archiv-version.js
+// pleace change "ARCHIV" in file webapp/constants/archiv-version.js
+const activeNetwork = true
+
 const allowExternalErrors = true
 
 const neode = getNeode()
@@ -110,37 +115,37 @@ export default shield(
       '*': deny,
       login: allow,
       SignupByInvitation: allow,
-      Signup: or(publicRegistration, isAdmin),
+      Signup: and(activeNetwork , or(publicRegistration, isAdmin)),
       SignupVerification: allow,
-      UpdateUser: onlyYourself,
-      CreatePost: isAuthenticated,
-      UpdatePost: isAuthor,
+      UpdateUser: and(activeNetwork, onlyYourself),
+      CreatePost: and(activeNetwork, isAuthenticated),
+      UpdatePost: and(activeNetwork, isAuthor),
       DeletePost: isAuthor,
       fileReport: isAuthenticated,
-      CreateSocialMedia: isAuthenticated,
-      UpdateSocialMedia: isMySocialMedia,
+      CreateSocialMedia: and(activeNetwork, isAuthenticated),
+      UpdateSocialMedia: and(activeNetwork, isMySocialMedia),
       DeleteSocialMedia: isMySocialMedia,
       // AddBadgeRewarded: isAdmin,
       // RemoveBadgeRewarded: isAdmin,
       reward: isAdmin,
       unreward: isAdmin,
-      followUser: isAuthenticated,
+      followUser: and(activeNetwork, isAuthenticated),
       unfollowUser: isAuthenticated,
-      shout: isAuthenticated,
+      shout: and(activeNetwork, isAuthenticated),
       unshout: isAuthenticated,
       changePassword: isAuthenticated,
       review: isModerator,
-      CreateComment: isAuthenticated,
-      UpdateComment: isAuthor,
+      CreateComment: and(activeNetwork, isAuthenticated),
+      UpdateComment: and(activeNetwork, isAuthor),
       DeleteComment: isAuthor,
       DeleteUser: or(isDeletingOwnAccount, isAdmin),
       requestPasswordReset: allow,
       resetPassword: allow,
-      AddPostEmotions: isAuthenticated,
+      AddPostEmotions: and(activeNetwork, isAuthenticated),
       RemovePostEmotions: isAuthenticated,
-      muteUser: isAuthenticated,
+      muteUser: and(activeNetwork, isAuthenticated),
       unmuteUser: isAuthenticated,
-      blockUser: isAuthenticated,
+      blockUser: and(activeNetwork, isAuthenticated),
       unblockUser: isAuthenticated,
       markAsRead: isAuthenticated,
       AddEmailAddress: isAuthenticated,

--- a/cypress/constants/archiv-version.js
+++ b/cypress/constants/archiv-version.js
@@ -1,0 +1,3 @@
+// please change also archiv version in file "webapp/constants/archiv-version.js"
+// pleace change "activeNetwork" in file backend/src/middleware/permissionsMiddleware.js
+export const activeNetwork = false

--- a/webapp/components/LoginForm/LoginForm.vue
+++ b/webapp/components/LoginForm/LoginForm.vue
@@ -35,10 +35,13 @@
         <base-button :loading="pending" filled name="submit" type="submit" icon="sign-in">
           {{ $t('login.login') }}
         </base-button>
-        <p>
+        <p v-if="activeNetwork">
           {{ $t('login.no-account') }}
           <nuxt-link to="/registration/signup">{{ $t('login.register') }}</nuxt-link>
         </p>
+        <p v-else >
+          <span>Archiv Modus. Read only!</span>
+          </p>
       </form>
       <template #topMenu>
         <locale-switch offset="5" />
@@ -49,6 +52,7 @@
 
 <script>
 import LocaleSwitch from '~/components/LocaleSwitch/LocaleSwitch'
+import ARCHIV from '~/constants/archiv-version.js'
 
 export default {
   components: {

--- a/webapp/constants/archiv-version.js
+++ b/webapp/constants/archiv-version.js
@@ -1,0 +1,3 @@
+// please change also archiv version in file "cypress/constants/archiv-version.js"
+// pleace change "activeNetwork" in file backend/src/middleware/permissionsMiddleware.js
+export const activeNetwork = true


### PR DESCRIPTION
## 🍰 Pullrequest
the network can be set to a read only mode. all contents can be read. 
all create and update functions are disabled. 
all delete functions remain. 

there is a global variable in webapp and backend 
"activeNetwork" 
which 
"true" = network normal (all functions are available)
or 
"false" = network in archive mode (read only)
can be. 

### Issues
- fixes #3863 



