### PR TITLE
build: Add semantic PR config

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,2 @@
+# Always validate the PR title, and ignore the commits
+titleOnly: true


### PR DESCRIPTION
- Added 'semantic.yml'.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

The semantic pull request doesn’t work if there is only one commit in the PR. That sometimes happen and then the semantic-PR mechanism fail.
I can and will not do a senseless second commit in a PR …

Description how to change this is here:
https://github.com/zeke/semantic-pull-requests#configuration

### Issues
<!-- Which Issues does this fix, which are related?
- relates #XXX
-->

- fixes #3883

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
