### PR TITLE
build: 🍰 Disable Codecov for last deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,8 @@ script:
   # - yarn run cypress:run --record
   # - yarn run cucumber
   # Coverage
-  - yarn run codecov
+  # disable this uneffective thing for last deploy, because of easyness!
+  # - yarn run codecov
 
 after_success:
   - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh


### PR DESCRIPTION
# 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Disable Codecov for last deploy.
Then we don't need the CODECOV_TOKEN on Travis.org.

### Issues
<!-- Which Issues does this fix, which are related?
- relates #XXX
-->
- fixes #3945

### Todo
<!-- In case some parts are still missing, list them here. -->

- [X] None
