### PR TITLE
Show time for older relative dates

### DIFF
--- a/webapp/components/RelativeDateTime/index.vue
+++ b/webapp/components/RelativeDateTime/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <span>{{ relativeDateTime }}</span>
+  <span :title="absoluteDateTime">{{ relativeDateTime }}</span>
 </template>
 
 <script>
@@ -19,16 +19,23 @@ export default {
     },
   },
   computed: {
+    date() {
+      return new Date(this.dateTime)
+    },
+    dateFnsLocale() {
+      return getDateFnsLocale(this)
+    },
+    absoluteDateTime() {
+      return format(this.date, 'Pp', { locale: this.dateFnsLocale })
+    },
     relativeDateTime() {
-      const date = new Date(this.dateTime)
-      const locale = getDateFnsLocale(this)
-      const calendarDayDistance = Math.abs(differenceInCalendarDays(date, new Date()))
+      const calendarDayDistance = Math.abs(differenceInCalendarDays(this.date, new Date()))
 
       if (calendarDayDistance > RELATIVE_DATE_WINDOW_DAYS) {
-        return format(date, 'Pp', { locale })
+        return this.absoluteDateTime
       }
 
-      return formatRelative(date, new Date(), { locale })
+      return formatRelative(this.date, new Date(), { locale: this.dateFnsLocale })
     },
   },
 }

--- a/webapp/components/RelativeDateTime/index.vue
+++ b/webapp/components/RelativeDateTime/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <span :title="absoluteDateTime">{{ relativeDateTime }}</span>
+  <time :datetime="machineDateTime" :title="absoluteDateTime">{{ relativeDateTime }}</time>
 </template>
 
 <script>
@@ -27,6 +27,9 @@ export default {
     },
     absoluteDateTime() {
       return format(this.date, 'Pp', { locale: this.dateFnsLocale })
+    },
+    machineDateTime() {
+      return this.date.toISOString()
     },
     relativeDateTime() {
       const calendarDayDistance = Math.abs(differenceInCalendarDays(this.date, new Date()))

--- a/webapp/components/RelativeDateTime/index.vue
+++ b/webapp/components/RelativeDateTime/index.vue
@@ -4,7 +4,11 @@
 
 <script>
 import { getDateFnsLocale } from '~/locales'
+import differenceInCalendarDays from 'date-fns/differenceInCalendarDays'
+import format from 'date-fns/format'
 import formatRelative from 'date-fns/formatRelative'
+
+const RELATIVE_DATE_WINDOW_DAYS = 6
 
 export default {
   name: 'HcRelativeDateTime',
@@ -16,7 +20,15 @@ export default {
   },
   computed: {
     relativeDateTime() {
-      return formatRelative(new Date(this.dateTime), new Date(), { locale: getDateFnsLocale(this) })
+      const date = new Date(this.dateTime)
+      const locale = getDateFnsLocale(this)
+      const calendarDayDistance = Math.abs(differenceInCalendarDays(date, new Date()))
+
+      if (calendarDayDistance > RELATIVE_DATE_WINDOW_DAYS) {
+        return format(date, 'Pp', { locale })
+      }
+
+      return formatRelative(date, new Date(), { locale })
     },
   },
 }

--- a/webapp/components/RelativeDateTime/spec.js
+++ b/webapp/components/RelativeDateTime/spec.js
@@ -46,7 +46,7 @@ describe('RelativeDateTime', () => {
     })
 
     it('renders', () => {
-      expect(Wrapper().is('span')).toBe(true)
+      expect(Wrapper().is('time')).toBe(true)
     })
 
     describe("locale == 'en'", () => {
@@ -93,6 +93,10 @@ describe('RelativeDateTime', () => {
 
     it('sets the absolute date with time as title', () => {
       expect(Wrapper().attributes('title')).toBe('03/08/2017, 5:45 PM')
+    })
+
+    it('sets a machine-readable datetime attribute', () => {
+      expect(Wrapper().attributes('datetime')).toBe(dateTime.toISOString())
     })
   })
 })

--- a/webapp/components/RelativeDateTime/spec.js
+++ b/webapp/components/RelativeDateTime/spec.js
@@ -90,5 +90,9 @@ describe('RelativeDateTime', () => {
       expect(Wrapper().text()).toContain('03/08/2017')
       expect(Wrapper().text()).toContain('5:45 PM')
     })
+
+    it('sets the absolute date with time as title', () => {
+      expect(Wrapper().attributes('title')).toBe('03/08/2017, 5:45 PM')
+    })
   })
 })

--- a/webapp/components/RelativeDateTime/spec.js
+++ b/webapp/components/RelativeDateTime/spec.js
@@ -34,6 +34,10 @@ describe('RelativeDateTime', () => {
     it('translates', () => {
       expect(Wrapper().text()).toContain('08/03/2017')
     })
+
+    it('keeps the time visible for old dates', () => {
+      expect(Wrapper().text()).toContain('12:00 AM')
+    })
   })
 
   describe('given a Date object as dateTime', () => {
@@ -73,6 +77,18 @@ describe('RelativeDateTime', () => {
       it('translates', () => {
         expect(Wrapper().text()).toContain('heute um')
       })
+    })
+  })
+
+  describe('given a Date object older than the relative date window', () => {
+    beforeEach(() => {
+      locale = 'en'
+      dateTime = new Date(2017, 2, 8, 17, 45)
+    })
+
+    it('renders the absolute date with time', () => {
+      expect(Wrapper().text()).toContain('03/08/2017')
+      expect(Wrapper().text()).toContain('5:45 PM')
     })
   })
 })


### PR DESCRIPTION
## Summary

- Keep relative labels for recent dates.
- Show an absolute localized date and time once a timestamp is outside the `formatRelative` window.
- Render the timestamp as a semantic `<time>` element with a localized `title` and machine-readable `datetime` attribute.
- Add regression coverage so old post/comment timestamps keep a visible time component.

Fixes #3014

## Validation

```bash
cd webapp
./node_modules/.bin/jest components/RelativeDateTime/spec.js --runInBand
./node_modules/.bin/eslint components/RelativeDateTime/index.vue components/RelativeDateTime/spec.js
git diff --check
```

Result: 9 tests passed; eslint passed; diff check clean.

Repository note: maintainers indicated active development has moved to the Ocelot Social fork, so this PR is kept focused and review-ready without additional churn.
